### PR TITLE
docker-entrypoint.sh: skip galera plugin on db initialization

### DIFF
--- a/10.1/docker-entrypoint.sh
+++ b/10.1/docker-entrypoint.sh
@@ -102,7 +102,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"
-		"$@" --skip-networking --socket="${SOCKET}" &
+		"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
 		pid="$!"
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )

--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -102,7 +102,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"
-		"$@" --skip-networking --socket="${SOCKET}" &
+		"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
 		pid="$!"
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -102,7 +102,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"
-		"$@" --skip-networking --socket="${SOCKET}" &
+		"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
 		pid="$!"
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -102,7 +102,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"
-		"$@" --skip-networking --socket="${SOCKET}" &
+		"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
 		pid="$!"
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -102,7 +102,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'Database initialized'
 
 		SOCKET="$(_get_config 'socket' "$@")"
-		"$@" --skip-networking --socket="${SOCKET}" &
+		"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
 		pid="$!"
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )


### PR DESCRIPTION
when provisioning additional nodes into an existing galera cluster, mariadb tries to sync, but then aborts.

This is due to the timeout of 30s in the bootstrapping section. This MR would just disable galera for init.
An alternative option would be to parse the config and skip init if wsrep_on=ON in any config file

Please regard this as a suggestion, which needs some checking.