### PR TITLE
10.2 build fail with latest Ubuntu bionic image

### DIFF
--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -15,6 +15,8 @@ RUN set -ex; \
 # so, if we're not running gnupg 1.x, explicitly install dirmngr too
 		apt-get install -y --no-install-recommends dirmngr; \
 	fi; \
+        mkdir ~/.gnupg; \
+        echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
 	rm -rf /var/lib/apt/lists/*
 
 # add gosu for easy step-down from root


### PR DESCRIPTION
With the latest Ubuntu bionic image, build will fail in step 9 with the error: 'gpg: keyserver receive failed: Cannot assign requested address'