### PR TITLE
MARIADB_RANDOM_ROOT_PASSWORD - much more random

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -252,7 +252,7 @@ docker_setup_db() {
 	fi
 	# Generate random root password
 	if [ -n "$MARIADB_RANDOM_ROOT_PASSWORD" ]; then
-		export MARIADB_ROOT_PASSWORD="$(pwgen -1 32)"
+		export MARIADB_ROOT_PASSWORD="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
 		export MYSQL_ROOT_PASSWORD=$MARIADB_ROOT_PASSWORD
 		mysql_note "GENERATED ROOT PASSWORD: $MARIADB_ROOT_PASSWORD"
 	fi

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -252,7 +252,7 @@ docker_setup_db() {
 	fi
 	# Generate random root password
 	if [ -n "$MARIADB_RANDOM_ROOT_PASSWORD" ]; then
-		export MARIADB_ROOT_PASSWORD="$(pwgen -1 32)"
+		export MARIADB_ROOT_PASSWORD="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
 		export MYSQL_ROOT_PASSWORD=$MARIADB_ROOT_PASSWORD
 		mysql_note "GENERATED ROOT PASSWORD: $MARIADB_ROOT_PASSWORD"
 	fi

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -252,7 +252,7 @@ docker_setup_db() {
 	fi
 	# Generate random root password
 	if [ -n "$MARIADB_RANDOM_ROOT_PASSWORD" ]; then
-		export MARIADB_ROOT_PASSWORD="$(pwgen -1 32)"
+		export MARIADB_ROOT_PASSWORD="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
 		export MYSQL_ROOT_PASSWORD=$MARIADB_ROOT_PASSWORD
 		mysql_note "GENERATED ROOT PASSWORD: $MARIADB_ROOT_PASSWORD"
 	fi

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -252,7 +252,7 @@ docker_setup_db() {
 	fi
 	# Generate random root password
 	if [ -n "$MARIADB_RANDOM_ROOT_PASSWORD" ]; then
-		export MARIADB_ROOT_PASSWORD="$(pwgen -1 32)"
+		export MARIADB_ROOT_PASSWORD="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
 		export MYSQL_ROOT_PASSWORD=$MARIADB_ROOT_PASSWORD
 		mysql_note "GENERATED ROOT PASSWORD: $MARIADB_ROOT_PASSWORD"
 	fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -252,7 +252,7 @@ docker_setup_db() {
 	fi
 	# Generate random root password
 	if [ -n "$MARIADB_RANDOM_ROOT_PASSWORD" ]; then
-		export MARIADB_ROOT_PASSWORD="$(pwgen -1 32)"
+		export MARIADB_ROOT_PASSWORD="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
 		export MYSQL_ROOT_PASSWORD=$MARIADB_ROOT_PASSWORD
 		mysql_note "GENERATED ROOT PASSWORD: $MARIADB_ROOT_PASSWORD"
 	fi


### PR DESCRIPTION
With https://mariadb.com/kb/en/password-validation/#examples
it may be the case that the random root password fails
to meet the complexity requirements.

We take advantage that both bionic (for 10.2) and focal
onwards include pwgen-2.08 that included the added options
to be secure on multiple ways.

Though not necessary, take away a few characters in
realization that the scripting ability of our users
may not contain the basic escaping needed to process
this added security.