### PR TITLE
socket directory permission fix if volume

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -163,6 +163,8 @@ docker_create_db_directories() {
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql -exec chown mysql '{}' +
+		# See https://github.com/MariaDB/mariadb-docker/issues/363
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql '{}' \;
 	fi
 }
 

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -163,6 +163,8 @@ docker_create_db_directories() {
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql -exec chown mysql '{}' +
+		# See https://github.com/MariaDB/mariadb-docker/issues/363
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql '{}' \;
 	fi
 }
 

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -163,6 +163,8 @@ docker_create_db_directories() {
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql -exec chown mysql '{}' +
+		# See https://github.com/MariaDB/mariadb-docker/issues/363
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql '{}' \;
 	fi
 }
 

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -163,6 +163,8 @@ docker_create_db_directories() {
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql -exec chown mysql '{}' +
+		# See https://github.com/MariaDB/mariadb-docker/issues/363
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql '{}' \;
 	fi
 }
 

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -163,6 +163,8 @@ docker_create_db_directories() {
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql -exec chown mysql '{}' +
+		# See https://github.com/MariaDB/mariadb-docker/issues/363
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql '{}' \;
 	fi
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -163,6 +163,8 @@ docker_create_db_directories() {
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql -exec chown mysql '{}' +
+		# See https://github.com/MariaDB/mariadb-docker/issues/363
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql '{}' \;
 	fi
 }
 


### PR DESCRIPTION
The socket directory may be a volume with
its ownership being that of root.

This correct that ownership to be of user mysql
to facilitate it starting.

Thanks @o-alquimista for the bug report.

closes #363.