### PR TITLE
Override time-zone option when initializing database

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -116,7 +116,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
-	"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
+	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF &
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -177,7 +177,7 @@ docker_init_database_dir() {
 		installArgs+=( --skip-test-db )
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-	mysql_install_db "${installArgs[@]}" "${@:2}"
+	mysql_install_db "${installArgs[@]}" "${@:2}" --default-time-zone=SYSTEM
 	mysql_note "Database files initialized"
 }
 

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -116,7 +116,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
-	"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
+	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF &
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -177,7 +177,7 @@ docker_init_database_dir() {
 		installArgs+=( --skip-test-db )
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-	mysql_install_db "${installArgs[@]}" "${@:2}"
+	mysql_install_db "${installArgs[@]}" "${@:2}" --default-time-zone=SYSTEM
 	mysql_note "Database files initialized"
 }
 

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -116,7 +116,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
-	"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
+	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF &
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -177,7 +177,7 @@ docker_init_database_dir() {
 		installArgs+=( --skip-test-db )
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-	mysql_install_db "${installArgs[@]}" "${@:2}"
+	mysql_install_db "${installArgs[@]}" "${@:2}" --default-time-zone=SYSTEM
 	mysql_note "Database files initialized"
 }
 

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -116,7 +116,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
-	"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
+	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF &
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -177,7 +177,7 @@ docker_init_database_dir() {
 		installArgs+=( --skip-test-db )
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-	mysql_install_db "${installArgs[@]}" "${@:2}"
+	mysql_install_db "${installArgs[@]}" "${@:2}" --default-time-zone=SYSTEM
 	mysql_note "Database files initialized"
 }
 

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -116,7 +116,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
-	"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
+	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF &
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -177,7 +177,7 @@ docker_init_database_dir() {
 		installArgs+=( --skip-test-db )
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-	mysql_install_db "${installArgs[@]}" "${@:2}"
+	mysql_install_db "${installArgs[@]}" "${@:2}" --default-time-zone=SYSTEM
 	mysql_note "Database files initialized"
 }
 

--- a/10.7/docker-entrypoint.sh
+++ b/10.7/docker-entrypoint.sh
@@ -116,7 +116,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
-	"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
+	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF &
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -177,7 +177,7 @@ docker_init_database_dir() {
 		installArgs+=( --skip-test-db )
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-	mysql_install_db "${installArgs[@]}" "${@:2}"
+	mysql_install_db "${installArgs[@]}" "${@:2}" --default-time-zone=SYSTEM
 	mysql_note "Database files initialized"
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -116,7 +116,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
-	"$@" --skip-networking --socket="${SOCKET}" --wsrep_on=OFF &
+	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF &
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -177,7 +177,7 @@ docker_init_database_dir() {
 		installArgs+=( --skip-test-db )
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
-	mysql_install_db "${installArgs[@]}" "${@:2}"
+	mysql_install_db "${installArgs[@]}" "${@:2}" --default-time-zone=SYSTEM
 	mysql_note "Database files initialized"
 }
 


### PR DESCRIPTION
# Situation
mariadb docker tag: 10.5 (pulled on 2021-08-04)
```
$ mkdir conf.d
$ echo -e "[mysqld]\ndefault_time_zone = 'Europe/Berlin'" > conf.d/my.cnf
$ docker run -it --rm -v $PWD/conf.d:/etc/mysql/conf.d -e MARIADB_RANDOM_ROOT_PASSWORD=yes mariadb:10.5
```

# Observed behaviour
the container crashes after printing:
```
2021-08-04 16:17:20 0 [ERROR] Fatal error: Illegal or unknown default time zone 'Europe/Berlin'
2021-08-04 16:17:20 0 [ERROR] Aborting
```

# Expected behaviour
MariaDB initializes properly and is configured with timezone 'Europe/Berlin'
```
MariaDB [(none)]> SHOW GLOBAL VARIABLES LIKE 'time_zone';
+---------------+---------------+
| Variable_name | Value         |
+---------------+---------------+
| time_zone     | Europe/Berlin |
+---------------+---------------+
1 row in set (0.001 sec)
```

# Comment
I'm just copying the changes made to the mysql docker-entrypoint.sh.

https://github.com/docker-library/mysql/pull/739
https://github.com/docker-library/mysql/issues/543

With this change I can set default_time_zone in a .cnf in the container before initializing the database. Otherwise I would have to initialize the database first without timezone and later add the .cnf.

If there are subtle differences between mariadb and mysql that make this change impossible, I apologize in advance.

I did a quickfix for my own mariadb image:
```
RUN sed -i -e 's/\(\$@" -\)/\1-default-time-zone=SYSTEM -/' /usr/local/bin/docker-entrypoint.sh
```
This only applies the change I propose in this PR in one location (instead of the two that are in this PR). But it works for me.