### PR TITLE
Add $MARIADB_MYSQL_LOCALHOST_GRANTS for mysql@localhost

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -292,6 +292,31 @@ docker_setup_db() {
 		EOSQL
 	fi
 
+	local mysqlAtLocalhost=
+	local mysqlAtLocalhostGrants=
+	# Install mysql@localhost user
+	if [ -n "$MARIADB_MYSQL_LOCALHOST_USER" ] || [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+		local pw=
+		pw="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
+		# MDEV-24111 before MariaDB-10.4 cannot create unix_socket user directly auth with simple_password_check
+		# It wasn't until 10.4 that the unix_socket auth was built in to the server.
+		read -r -d '' mysqlAtLocalhost <<-EOSQL || true
+		EXECUTE IMMEDIATE IF(VERSION() RLIKE '^10\.[23]\.',
+			"INSTALL PLUGIN /*M10401 IF NOT EXISTS */ unix_socket SONAME 'auth_socket'",
+			"SELECT 'already there'");
+		CREATE USER mysql@localhost IDENTIFIED BY '$pw';
+		ALTER USER mysql@localhost IDENTIFIED VIA unix_socket;
+		EOSQL
+		if [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+			if [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = ALL* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *UPDATE* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *INSERT* ]]; then
+				mysql_warn "ALL/INSERT/UPDATE privileges ON *.* TO mysql@localhost facilitates privilege escalation, recommending limiting to required privileges"
+			fi
+			mysqlAtLocalhostGrants="GRANT ${MARIADB_MYSQL_LOCALHOST_GRANTS} ON *.* TO mysql@localhost;";
+		fi
+	fi
+
 	mysql_note "Securing system users (equivalent to running mysql_secure_installation)"
 	# tell docker_process_sql to not use MARIADB_ROOT_PASSWORD since it is just now being set
 	# --binary-mode to save us from the semi-mad users go out of their way to confuse the encoding.
@@ -307,6 +332,8 @@ docker_setup_db() {
 
 		SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${rootPasswordEscaped}') ;
 		${rootCreate}
+		${mysqlAtLocalhost}
+		${mysqlAtLocalhostGrants}
 		-- pre-10.3
 		DROP DATABASE IF EXISTS test ;
 	EOSQL

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -292,6 +292,31 @@ docker_setup_db() {
 		EOSQL
 	fi
 
+	local mysqlAtLocalhost=
+	local mysqlAtLocalhostGrants=
+	# Install mysql@localhost user
+	if [ -n "$MARIADB_MYSQL_LOCALHOST_USER" ] || [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+		local pw=
+		pw="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
+		# MDEV-24111 before MariaDB-10.4 cannot create unix_socket user directly auth with simple_password_check
+		# It wasn't until 10.4 that the unix_socket auth was built in to the server.
+		read -r -d '' mysqlAtLocalhost <<-EOSQL || true
+		EXECUTE IMMEDIATE IF(VERSION() RLIKE '^10\.[23]\.',
+			"INSTALL PLUGIN /*M10401 IF NOT EXISTS */ unix_socket SONAME 'auth_socket'",
+			"SELECT 'already there'");
+		CREATE USER mysql@localhost IDENTIFIED BY '$pw';
+		ALTER USER mysql@localhost IDENTIFIED VIA unix_socket;
+		EOSQL
+		if [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+			if [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = ALL* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *UPDATE* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *INSERT* ]]; then
+				mysql_warn "ALL/INSERT/UPDATE privileges ON *.* TO mysql@localhost facilitates privilege escalation, recommending limiting to required privileges"
+			fi
+			mysqlAtLocalhostGrants="GRANT ${MARIADB_MYSQL_LOCALHOST_GRANTS} ON *.* TO mysql@localhost;";
+		fi
+	fi
+
 	mysql_note "Securing system users (equivalent to running mysql_secure_installation)"
 	# tell docker_process_sql to not use MARIADB_ROOT_PASSWORD since it is just now being set
 	# --binary-mode to save us from the semi-mad users go out of their way to confuse the encoding.
@@ -307,6 +332,8 @@ docker_setup_db() {
 
 		SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${rootPasswordEscaped}') ;
 		${rootCreate}
+		${mysqlAtLocalhost}
+		${mysqlAtLocalhostGrants}
 		-- pre-10.3
 		DROP DATABASE IF EXISTS test ;
 	EOSQL

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -292,6 +292,31 @@ docker_setup_db() {
 		EOSQL
 	fi
 
+	local mysqlAtLocalhost=
+	local mysqlAtLocalhostGrants=
+	# Install mysql@localhost user
+	if [ -n "$MARIADB_MYSQL_LOCALHOST_USER" ] || [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+		local pw=
+		pw="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
+		# MDEV-24111 before MariaDB-10.4 cannot create unix_socket user directly auth with simple_password_check
+		# It wasn't until 10.4 that the unix_socket auth was built in to the server.
+		read -r -d '' mysqlAtLocalhost <<-EOSQL || true
+		EXECUTE IMMEDIATE IF(VERSION() RLIKE '^10\.[23]\.',
+			"INSTALL PLUGIN /*M10401 IF NOT EXISTS */ unix_socket SONAME 'auth_socket'",
+			"SELECT 'already there'");
+		CREATE USER mysql@localhost IDENTIFIED BY '$pw';
+		ALTER USER mysql@localhost IDENTIFIED VIA unix_socket;
+		EOSQL
+		if [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+			if [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = ALL* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *UPDATE* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *INSERT* ]]; then
+				mysql_warn "ALL/INSERT/UPDATE privileges ON *.* TO mysql@localhost facilitates privilege escalation, recommending limiting to required privileges"
+			fi
+			mysqlAtLocalhostGrants="GRANT ${MARIADB_MYSQL_LOCALHOST_GRANTS} ON *.* TO mysql@localhost;";
+		fi
+	fi
+
 	mysql_note "Securing system users (equivalent to running mysql_secure_installation)"
 	# tell docker_process_sql to not use MARIADB_ROOT_PASSWORD since it is just now being set
 	# --binary-mode to save us from the semi-mad users go out of their way to confuse the encoding.
@@ -307,6 +332,8 @@ docker_setup_db() {
 
 		SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${rootPasswordEscaped}') ;
 		${rootCreate}
+		${mysqlAtLocalhost}
+		${mysqlAtLocalhostGrants}
 		-- pre-10.3
 		DROP DATABASE IF EXISTS test ;
 	EOSQL

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -292,6 +292,31 @@ docker_setup_db() {
 		EOSQL
 	fi
 
+	local mysqlAtLocalhost=
+	local mysqlAtLocalhostGrants=
+	# Install mysql@localhost user
+	if [ -n "$MARIADB_MYSQL_LOCALHOST_USER" ] || [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+		local pw=
+		pw="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
+		# MDEV-24111 before MariaDB-10.4 cannot create unix_socket user directly auth with simple_password_check
+		# It wasn't until 10.4 that the unix_socket auth was built in to the server.
+		read -r -d '' mysqlAtLocalhost <<-EOSQL || true
+		EXECUTE IMMEDIATE IF(VERSION() RLIKE '^10\.[23]\.',
+			"INSTALL PLUGIN /*M10401 IF NOT EXISTS */ unix_socket SONAME 'auth_socket'",
+			"SELECT 'already there'");
+		CREATE USER mysql@localhost IDENTIFIED BY '$pw';
+		ALTER USER mysql@localhost IDENTIFIED VIA unix_socket;
+		EOSQL
+		if [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+			if [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = ALL* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *UPDATE* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *INSERT* ]]; then
+				mysql_warn "ALL/INSERT/UPDATE privileges ON *.* TO mysql@localhost facilitates privilege escalation, recommending limiting to required privileges"
+			fi
+			mysqlAtLocalhostGrants="GRANT ${MARIADB_MYSQL_LOCALHOST_GRANTS} ON *.* TO mysql@localhost;";
+		fi
+	fi
+
 	mysql_note "Securing system users (equivalent to running mysql_secure_installation)"
 	# tell docker_process_sql to not use MARIADB_ROOT_PASSWORD since it is just now being set
 	# --binary-mode to save us from the semi-mad users go out of their way to confuse the encoding.
@@ -307,6 +332,8 @@ docker_setup_db() {
 
 		SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${rootPasswordEscaped}') ;
 		${rootCreate}
+		${mysqlAtLocalhost}
+		${mysqlAtLocalhostGrants}
 		-- pre-10.3
 		DROP DATABASE IF EXISTS test ;
 	EOSQL

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -292,6 +292,31 @@ docker_setup_db() {
 		EOSQL
 	fi
 
+	local mysqlAtLocalhost=
+	local mysqlAtLocalhostGrants=
+	# Install mysql@localhost user
+	if [ -n "$MARIADB_MYSQL_LOCALHOST_USER" ] || [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+		local pw=
+		pw="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
+		# MDEV-24111 before MariaDB-10.4 cannot create unix_socket user directly auth with simple_password_check
+		# It wasn't until 10.4 that the unix_socket auth was built in to the server.
+		read -r -d '' mysqlAtLocalhost <<-EOSQL || true
+		EXECUTE IMMEDIATE IF(VERSION() RLIKE '^10\.[23]\.',
+			"INSTALL PLUGIN /*M10401 IF NOT EXISTS */ unix_socket SONAME 'auth_socket'",
+			"SELECT 'already there'");
+		CREATE USER mysql@localhost IDENTIFIED BY '$pw';
+		ALTER USER mysql@localhost IDENTIFIED VIA unix_socket;
+		EOSQL
+		if [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+			if [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = ALL* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *UPDATE* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *INSERT* ]]; then
+				mysql_warn "ALL/INSERT/UPDATE privileges ON *.* TO mysql@localhost facilitates privilege escalation, recommending limiting to required privileges"
+			fi
+			mysqlAtLocalhostGrants="GRANT ${MARIADB_MYSQL_LOCALHOST_GRANTS} ON *.* TO mysql@localhost;";
+		fi
+	fi
+
 	mysql_note "Securing system users (equivalent to running mysql_secure_installation)"
 	# tell docker_process_sql to not use MARIADB_ROOT_PASSWORD since it is just now being set
 	# --binary-mode to save us from the semi-mad users go out of their way to confuse the encoding.
@@ -307,6 +332,8 @@ docker_setup_db() {
 
 		SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${rootPasswordEscaped}') ;
 		${rootCreate}
+		${mysqlAtLocalhost}
+		${mysqlAtLocalhostGrants}
 		-- pre-10.3
 		DROP DATABASE IF EXISTS test ;
 	EOSQL

--- a/10.7/docker-entrypoint.sh
+++ b/10.7/docker-entrypoint.sh
@@ -292,6 +292,31 @@ docker_setup_db() {
 		EOSQL
 	fi
 
+	local mysqlAtLocalhost=
+	local mysqlAtLocalhostGrants=
+	# Install mysql@localhost user
+	if [ -n "$MARIADB_MYSQL_LOCALHOST_USER" ] || [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+		local pw=
+		pw="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
+		# MDEV-24111 before MariaDB-10.4 cannot create unix_socket user directly auth with simple_password_check
+		# It wasn't until 10.4 that the unix_socket auth was built in to the server.
+		read -r -d '' mysqlAtLocalhost <<-EOSQL || true
+		EXECUTE IMMEDIATE IF(VERSION() RLIKE '^10\.[23]\.',
+			"INSTALL PLUGIN /*M10401 IF NOT EXISTS */ unix_socket SONAME 'auth_socket'",
+			"SELECT 'already there'");
+		CREATE USER mysql@localhost IDENTIFIED BY '$pw';
+		ALTER USER mysql@localhost IDENTIFIED VIA unix_socket;
+		EOSQL
+		if [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+			if [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = ALL* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *UPDATE* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *INSERT* ]]; then
+				mysql_warn "ALL/INSERT/UPDATE privileges ON *.* TO mysql@localhost facilitates privilege escalation, recommending limiting to required privileges"
+			fi
+			mysqlAtLocalhostGrants="GRANT ${MARIADB_MYSQL_LOCALHOST_GRANTS} ON *.* TO mysql@localhost;";
+		fi
+	fi
+
 	mysql_note "Securing system users (equivalent to running mysql_secure_installation)"
 	# tell docker_process_sql to not use MARIADB_ROOT_PASSWORD since it is just now being set
 	# --binary-mode to save us from the semi-mad users go out of their way to confuse the encoding.
@@ -307,6 +332,8 @@ docker_setup_db() {
 
 		SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${rootPasswordEscaped}') ;
 		${rootCreate}
+		${mysqlAtLocalhost}
+		${mysqlAtLocalhostGrants}
 		-- pre-10.3
 		DROP DATABASE IF EXISTS test ;
 	EOSQL

--- a/10.8/docker-entrypoint.sh
+++ b/10.8/docker-entrypoint.sh
@@ -292,6 +292,31 @@ docker_setup_db() {
 		EOSQL
 	fi
 
+	local mysqlAtLocalhost=
+	local mysqlAtLocalhostGrants=
+	# Install mysql@localhost user
+	if [ -n "$MARIADB_MYSQL_LOCALHOST_USER" ] || [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+		local pw=
+		pw="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
+		# MDEV-24111 before MariaDB-10.4 cannot create unix_socket user directly auth with simple_password_check
+		# It wasn't until 10.4 that the unix_socket auth was built in to the server.
+		read -r -d '' mysqlAtLocalhost <<-EOSQL || true
+		EXECUTE IMMEDIATE IF(VERSION() RLIKE '^10\.[23]\.',
+			"INSTALL PLUGIN /*M10401 IF NOT EXISTS */ unix_socket SONAME 'auth_socket'",
+			"SELECT 'already there'");
+		CREATE USER mysql@localhost IDENTIFIED BY '$pw';
+		ALTER USER mysql@localhost IDENTIFIED VIA unix_socket;
+		EOSQL
+		if [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+			if [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = ALL* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *UPDATE* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *INSERT* ]]; then
+				mysql_warn "ALL/INSERT/UPDATE privileges ON *.* TO mysql@localhost facilitates privilege escalation, recommending limiting to required privileges"
+			fi
+			mysqlAtLocalhostGrants="GRANT ${MARIADB_MYSQL_LOCALHOST_GRANTS} ON *.* TO mysql@localhost;";
+		fi
+	fi
+
 	mysql_note "Securing system users (equivalent to running mysql_secure_installation)"
 	# tell docker_process_sql to not use MARIADB_ROOT_PASSWORD since it is just now being set
 	# --binary-mode to save us from the semi-mad users go out of their way to confuse the encoding.
@@ -307,6 +332,8 @@ docker_setup_db() {
 
 		SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${rootPasswordEscaped}') ;
 		${rootCreate}
+		${mysqlAtLocalhost}
+		${mysqlAtLocalhostGrants}
 		-- pre-10.3
 		DROP DATABASE IF EXISTS test ;
 	EOSQL

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -292,6 +292,31 @@ docker_setup_db() {
 		EOSQL
 	fi
 
+	local mysqlAtLocalhost=
+	local mysqlAtLocalhostGrants=
+	# Install mysql@localhost user
+	if [ -n "$MARIADB_MYSQL_LOCALHOST_USER" ] || [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+		local pw=
+		pw="$(pwgen --numerals --capitalize --symbols --remove-chars="'\\" -1 32)"
+		# MDEV-24111 before MariaDB-10.4 cannot create unix_socket user directly auth with simple_password_check
+		# It wasn't until 10.4 that the unix_socket auth was built in to the server.
+		read -r -d '' mysqlAtLocalhost <<-EOSQL || true
+		EXECUTE IMMEDIATE IF(VERSION() RLIKE '^10\.[23]\.',
+			"INSTALL PLUGIN /*M10401 IF NOT EXISTS */ unix_socket SONAME 'auth_socket'",
+			"SELECT 'already there'");
+		CREATE USER mysql@localhost IDENTIFIED BY '$pw';
+		ALTER USER mysql@localhost IDENTIFIED VIA unix_socket;
+		EOSQL
+		if [ -n "$MARIADB_MYSQL_LOCALHOST_GRANTS" ]; then
+			if [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = ALL* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *UPDATE* ]] || \
+			   [[ "$MARIADB_MYSQL_LOCALHOST_GRANTS" = *INSERT* ]]; then
+				mysql_warn "ALL/INSERT/UPDATE privileges ON *.* TO mysql@localhost facilitates privilege escalation, recommending limiting to required privileges"
+			fi
+			mysqlAtLocalhostGrants="GRANT ${MARIADB_MYSQL_LOCALHOST_GRANTS} ON *.* TO mysql@localhost;";
+		fi
+	fi
+
 	mysql_note "Securing system users (equivalent to running mysql_secure_installation)"
 	# tell docker_process_sql to not use MARIADB_ROOT_PASSWORD since it is just now being set
 	# --binary-mode to save us from the semi-mad users go out of their way to confuse the encoding.
@@ -307,6 +332,8 @@ docker_setup_db() {
 
 		SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${rootPasswordEscaped}') ;
 		${rootCreate}
+		${mysqlAtLocalhost}
+		${mysqlAtLocalhostGrants}
 		-- pre-10.3
 		DROP DATABASE IF EXISTS test ;
 	EOSQL


### PR DESCRIPTION
Monitoring and backups require authentication.

The healthcheck script as a executed within container is a perfect
example. Having another password to manage on a privileged account
is an additional maintaince burden. With unix_socket authentication
this provides easy access for what will already have direct access
to database files.

Different monitoring requires different level of grants.

The security is documented in https://mariadb.com/kb/en/authentication-plugin-unix-socket/#is-it-secure
with all the container based security considerations easy to assess.

As mariabackup is also executed within the container, its use is very
similary.

The reuse of the name to contain the list of grants is only a proof of
concept. Other suggestions welcome.

@PhrozenByte any comments/suggestions?