### PR TITLE
Mariadb upgrade shutdown

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -404,19 +404,8 @@ docker_mariadb_upgrade() {
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
 	kill "$MARIADB_PID"
-	while killall -0 "$MARIADB_PID" ; do
-		sleep 1
-	done > /dev/null
+	wait "$MARIADB_PID"
 	mysql_note "Temporary server stopped"
-
-	local aria_control="$DATADIR"/aria_log_control
-	if [ -f "$aria_control" ]; then
-		mysql_note "Ensuring temporary server process really gone by locking $aria_control"
-		until flock --exclusive --wait 2 -n 9 9<"$aria_control"; do
-			mysql_note "Waiting 2 more seconds ..."
-		done
-		sleep 2
-	fi
 }
 
 

--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -122,6 +122,8 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF --skip-log-bin \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
+	declare -g MARIADB_PID
+	MARIADB_PID=$!
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -390,7 +392,6 @@ docker_mariadb_upgrade() {
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
-	local pid=$!
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -402,8 +403,8 @@ docker_mariadb_upgrade() {
 	# docker_temp_server_stop needs authentication since
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
-	kill "$pid"
-	while killall -0 "$pid" ; do
+	kill "$MARIADB_PID"
+	while killall -0 "$MARIADB_PID" ; do
 		sleep 1
 	done > /dev/null
 	mysql_note "Temporary server stopped"

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -404,19 +404,8 @@ docker_mariadb_upgrade() {
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
 	kill "$MARIADB_PID"
-	while killall -0 "$MARIADB_PID" ; do
-		sleep 1
-	done > /dev/null
+	wait "$MARIADB_PID"
 	mysql_note "Temporary server stopped"
-
-	local aria_control="$DATADIR"/aria_log_control
-	if [ -f "$aria_control" ]; then
-		mysql_note "Ensuring temporary server process really gone by locking $aria_control"
-		until flock --exclusive --wait 2 -n 9 9<"$aria_control"; do
-			mysql_note "Waiting 2 more seconds ..."
-		done
-		sleep 2
-	fi
 }
 
 

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -122,6 +122,8 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF --skip-log-bin \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
+	declare -g MARIADB_PID
+	MARIADB_PID=$!
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -390,7 +392,6 @@ docker_mariadb_upgrade() {
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
-	local pid=$!
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -402,8 +403,8 @@ docker_mariadb_upgrade() {
 	# docker_temp_server_stop needs authentication since
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
-	kill "$pid"
-	while killall -0 "$pid" ; do
+	kill "$MARIADB_PID"
+	while killall -0 "$MARIADB_PID" ; do
 		sleep 1
 	done > /dev/null
 	mysql_note "Temporary server stopped"

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -404,19 +404,8 @@ docker_mariadb_upgrade() {
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
 	kill "$MARIADB_PID"
-	while killall -0 "$MARIADB_PID" ; do
-		sleep 1
-	done > /dev/null
+	wait "$MARIADB_PID"
 	mysql_note "Temporary server stopped"
-
-	local aria_control="$DATADIR"/aria_log_control
-	if [ -f "$aria_control" ]; then
-		mysql_note "Ensuring temporary server process really gone by locking $aria_control"
-		until flock --exclusive --wait 2 -n 9 9<"$aria_control"; do
-			mysql_note "Waiting 2 more seconds ..."
-		done
-		sleep 2
-	fi
 }
 
 

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -122,6 +122,8 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF --skip-log-bin \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
+	declare -g MARIADB_PID
+	MARIADB_PID=$!
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -390,7 +392,6 @@ docker_mariadb_upgrade() {
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
-	local pid=$!
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -402,8 +403,8 @@ docker_mariadb_upgrade() {
 	# docker_temp_server_stop needs authentication since
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
-	kill "$pid"
-	while killall -0 "$pid" ; do
+	kill "$MARIADB_PID"
+	while killall -0 "$MARIADB_PID" ; do
 		sleep 1
 	done > /dev/null
 	mysql_note "Temporary server stopped"

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -404,19 +404,8 @@ docker_mariadb_upgrade() {
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
 	kill "$MARIADB_PID"
-	while killall -0 "$MARIADB_PID" ; do
-		sleep 1
-	done > /dev/null
+	wait "$MARIADB_PID"
 	mysql_note "Temporary server stopped"
-
-	local aria_control="$DATADIR"/aria_log_control
-	if [ -f "$aria_control" ]; then
-		mysql_note "Ensuring temporary server process really gone by locking $aria_control"
-		until flock --exclusive --wait 2 -n 9 9<"$aria_control"; do
-			mysql_note "Waiting 2 more seconds ..."
-		done
-		sleep 2
-	fi
 }
 
 

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -122,6 +122,8 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF --skip-log-bin \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
+	declare -g MARIADB_PID
+	MARIADB_PID=$!
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -390,7 +392,6 @@ docker_mariadb_upgrade() {
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
-	local pid=$!
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -402,8 +403,8 @@ docker_mariadb_upgrade() {
 	# docker_temp_server_stop needs authentication since
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
-	kill "$pid"
-	while killall -0 "$pid" ; do
+	kill "$MARIADB_PID"
+	while killall -0 "$MARIADB_PID" ; do
 		sleep 1
 	done > /dev/null
 	mysql_note "Temporary server stopped"

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -404,19 +404,8 @@ docker_mariadb_upgrade() {
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
 	kill "$MARIADB_PID"
-	while killall -0 "$MARIADB_PID" ; do
-		sleep 1
-	done > /dev/null
+	wait "$MARIADB_PID"
 	mysql_note "Temporary server stopped"
-
-	local aria_control="$DATADIR"/aria_log_control
-	if [ -f "$aria_control" ]; then
-		mysql_note "Ensuring temporary server process really gone by locking $aria_control"
-		until flock --exclusive --wait 2 -n 9 9<"$aria_control"; do
-			mysql_note "Waiting 2 more seconds ..."
-		done
-		sleep 2
-	fi
 }
 
 

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -122,6 +122,8 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF --skip-log-bin \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
+	declare -g MARIADB_PID
+	MARIADB_PID=$!
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -390,7 +392,6 @@ docker_mariadb_upgrade() {
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
-	local pid=$!
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -402,8 +403,8 @@ docker_mariadb_upgrade() {
 	# docker_temp_server_stop needs authentication since
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
-	kill "$pid"
-	while killall -0 "$pid" ; do
+	kill "$MARIADB_PID"
+	while killall -0 "$MARIADB_PID" ; do
 		sleep 1
 	done > /dev/null
 	mysql_note "Temporary server stopped"

--- a/10.7/docker-entrypoint.sh
+++ b/10.7/docker-entrypoint.sh
@@ -404,19 +404,8 @@ docker_mariadb_upgrade() {
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
 	kill "$MARIADB_PID"
-	while killall -0 "$MARIADB_PID" ; do
-		sleep 1
-	done > /dev/null
+	wait "$MARIADB_PID"
 	mysql_note "Temporary server stopped"
-
-	local aria_control="$DATADIR"/aria_log_control
-	if [ -f "$aria_control" ]; then
-		mysql_note "Ensuring temporary server process really gone by locking $aria_control"
-		until flock --exclusive --wait 2 -n 9 9<"$aria_control"; do
-			mysql_note "Waiting 2 more seconds ..."
-		done
-		sleep 2
-	fi
 }
 
 

--- a/10.7/docker-entrypoint.sh
+++ b/10.7/docker-entrypoint.sh
@@ -122,6 +122,8 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF --skip-log-bin \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
+	declare -g MARIADB_PID
+	MARIADB_PID=$!
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -390,7 +392,6 @@ docker_mariadb_upgrade() {
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
-	local pid=$!
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -402,8 +403,8 @@ docker_mariadb_upgrade() {
 	# docker_temp_server_stop needs authentication since
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
-	kill "$pid"
-	while killall -0 "$pid" ; do
+	kill "$MARIADB_PID"
+	while killall -0 "$MARIADB_PID" ; do
 		sleep 1
 	done > /dev/null
 	mysql_note "Temporary server stopped"

--- a/10.8/docker-entrypoint.sh
+++ b/10.8/docker-entrypoint.sh
@@ -404,19 +404,8 @@ docker_mariadb_upgrade() {
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
 	kill "$MARIADB_PID"
-	while killall -0 "$MARIADB_PID" ; do
-		sleep 1
-	done > /dev/null
+	wait "$MARIADB_PID"
 	mysql_note "Temporary server stopped"
-
-	local aria_control="$DATADIR"/aria_log_control
-	if [ -f "$aria_control" ]; then
-		mysql_note "Ensuring temporary server process really gone by locking $aria_control"
-		until flock --exclusive --wait 2 -n 9 9<"$aria_control"; do
-			mysql_note "Waiting 2 more seconds ..."
-		done
-		sleep 2
-	fi
 }
 
 

--- a/10.8/docker-entrypoint.sh
+++ b/10.8/docker-entrypoint.sh
@@ -122,6 +122,8 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF --skip-log-bin \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
+	declare -g MARIADB_PID
+	MARIADB_PID=$!
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -390,7 +392,6 @@ docker_mariadb_upgrade() {
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
-	local pid=$!
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -402,8 +403,8 @@ docker_mariadb_upgrade() {
 	# docker_temp_server_stop needs authentication since
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
-	kill "$pid"
-	while killall -0 "$pid" ; do
+	kill "$MARIADB_PID"
+	while killall -0 "$MARIADB_PID" ; do
 		sleep 1
 	done > /dev/null
 	mysql_note "Temporary server stopped"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -404,19 +404,8 @@ docker_mariadb_upgrade() {
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
 	kill "$MARIADB_PID"
-	while killall -0 "$MARIADB_PID" ; do
-		sleep 1
-	done > /dev/null
+	wait "$MARIADB_PID"
 	mysql_note "Temporary server stopped"
-
-	local aria_control="$DATADIR"/aria_log_control
-	if [ -f "$aria_control" ]; then
-		mysql_note "Ensuring temporary server process really gone by locking $aria_control"
-		until flock --exclusive --wait 2 -n 9 9<"$aria_control"; do
-			mysql_note "Waiting 2 more seconds ..."
-		done
-		sleep 2
-	fi
 }
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -122,6 +122,8 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF --skip-log-bin \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
+	declare -g MARIADB_PID
+	MARIADB_PID=$!
 	mysql_note "Waiting for server startup"
 	# only use the root password if the database has already been initializaed
 	# so that it won't try to fill in a password file when it hasn't been set yet
@@ -390,7 +392,6 @@ docker_mariadb_upgrade() {
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
-	local pid=$!
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -402,8 +403,8 @@ docker_mariadb_upgrade() {
 	# docker_temp_server_stop needs authentication since
 	# upgrade ended in FLUSH PRIVILEGES
 	mysql_note "Stopping temporary server"
-	kill "$pid"
-	while killall -0 "$pid" ; do
+	kill "$MARIADB_PID"
+	while killall -0 "$MARIADB_PID" ; do
 		sleep 1
 	done > /dev/null
 	mysql_note "Temporary server stopped"


### PR DESCRIPTION
Addressing https://github.com/docker-library/official-images/pull/11864#issuecomment-1045549106

@yosifkit, acceptable? Improvements? Required for Feb 2022 release?

If its stable, we could look at moving the logic to `docker_temp_server_stop` next release.