### PR TITLE
tests: for replica provisioning

### DIFF
--- a/.test/initdb.d/repluser.sql
+++ b/.test/initdb.d/repluser.sql
@@ -1,0 +1,2 @@
+CREATE USER 'repluser' IDENTIFIED BY 'replsecret';
+GRANT REPLICATION SLAVE ON *.* TO 'repluser';

--- a/.test/replica-initdb.d/change-master.sh
+++ b/.test/replica-initdb.d/change-master.sh
@@ -1,0 +1,11 @@
+# Sourced, intentionally no shebang
+# shellcheck disable=SC2148
+docker_process_sql <<-EOSQL
+CHANGE MASTER TO
+   MASTER_HOST='${MASTER_HOST:-mariadbprimary}',
+   MASTER_USER='${MASTER_USER:-repluser}',
+   MASTER_PASSWORD='${MASTER_PASSWORD:-replsecret}',
+   MASTER_CONNECT_RETRY=3,
+   MASTER_LOG_FILE='my-mariadb-bin.000001',
+   MASTER_LOG_POS=4;
+EOSQL

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -39,7 +39,7 @@ trap "killoff" EXIT
 
 runandwait()
 {
-	cname="mariadb-container-$RANDOM-$RANDOM"
+	cname="mariadbcontainer$RANDOM"
 	cid="$(
 		docker run -d \
 			--name "$cname" --rm --publish 3306 "$@"


### PR DESCRIPTION
Using binary logging create replica contains is pretty standard so lets to a test case.