### PR TITLE
expire-logs-days=0 on install and temp_server_start

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
 	declare -g MARIADB_PID
 	MARIADB_PID=$!
@@ -194,7 +195,9 @@ docker_init_database_dir() {
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
 	mysql_install_db "${installArgs[@]}" "${@:2}" \
-		--default-time-zone=SYSTEM --enforce-storage-engine= --skip-log-bin \
+		--default-time-zone=SYSTEM --enforce-storage-engine= \
+		--skip-log-bin \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Database files initialized"

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
 	declare -g MARIADB_PID
 	MARIADB_PID=$!
@@ -194,7 +195,9 @@ docker_init_database_dir() {
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
 	mysql_install_db "${installArgs[@]}" "${@:2}" \
-		--default-time-zone=SYSTEM --enforce-storage-engine= --skip-log-bin \
+		--default-time-zone=SYSTEM --enforce-storage-engine= \
+		--skip-log-bin \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Database files initialized"

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
 	declare -g MARIADB_PID
 	MARIADB_PID=$!
@@ -194,7 +195,9 @@ docker_init_database_dir() {
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
 	mysql_install_db "${installArgs[@]}" "${@:2}" \
-		--default-time-zone=SYSTEM --enforce-storage-engine= --skip-log-bin \
+		--default-time-zone=SYSTEM --enforce-storage-engine= \
+		--skip-log-bin \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Database files initialized"

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
 	declare -g MARIADB_PID
 	MARIADB_PID=$!
@@ -194,7 +195,9 @@ docker_init_database_dir() {
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
 	mysql_install_db "${installArgs[@]}" "${@:2}" \
-		--default-time-zone=SYSTEM --enforce-storage-engine= --skip-log-bin \
+		--default-time-zone=SYSTEM --enforce-storage-engine= \
+		--skip-log-bin \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Database files initialized"

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
 	declare -g MARIADB_PID
 	MARIADB_PID=$!
@@ -194,7 +195,9 @@ docker_init_database_dir() {
 	fi
 	# "Other options are passed to mariadbd." (so we pass all "mysqld" arguments directly here)
 	mariadb-install-db "${installArgs[@]}" "${@:2}" \
-		--default-time-zone=SYSTEM --enforce-storage-engine= --skip-log-bin \
+		--default-time-zone=SYSTEM --enforce-storage-engine= \
+		--skip-log-bin \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Database files initialized"

--- a/10.7/docker-entrypoint.sh
+++ b/10.7/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
 	declare -g MARIADB_PID
 	MARIADB_PID=$!
@@ -194,7 +195,9 @@ docker_init_database_dir() {
 	fi
 	# "Other options are passed to mariadbd." (so we pass all "mysqld" arguments directly here)
 	mariadb-install-db "${installArgs[@]}" "${@:2}" \
-		--default-time-zone=SYSTEM --enforce-storage-engine= --skip-log-bin \
+		--default-time-zone=SYSTEM --enforce-storage-engine= \
+		--skip-log-bin \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Database files initialized"

--- a/10.8/docker-entrypoint.sh
+++ b/10.8/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
 	declare -g MARIADB_PID
 	MARIADB_PID=$!
@@ -194,7 +195,9 @@ docker_init_database_dir() {
 	fi
 	# "Other options are passed to mariadbd." (so we pass all "mysqld" arguments directly here)
 	mariadb-install-db "${installArgs[@]}" "${@:2}" \
-		--default-time-zone=SYSTEM --enforce-storage-engine= --skip-log-bin \
+		--default-time-zone=SYSTEM --enforce-storage-engine= \
+		--skip-log-bin \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Database files initialized"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 # Do a temporary startup of the MariaDB server, for init purposes
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 &
 	declare -g MARIADB_PID
 	MARIADB_PID=$!
@@ -194,7 +195,9 @@ docker_init_database_dir() {
 	fi
 	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
 	mysql_install_db "${installArgs[@]}" "${@:2}" \
-		--default-time-zone=SYSTEM --enforce-storage-engine= --skip-log-bin \
+		--default-time-zone=SYSTEM --enforce-storage-engine= \
+		--skip-log-bin \
+		--expire-logs-days=0 \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Database files initialized"


### PR DESCRIPTION
This prevents the warning "You need to use --log-bin to make
--expire-logs-days or --binlog-expire-logs-seconds work"
in 10.6+.

Cause, is that expire_logs_days is set in the default
configuration
(https://github.com/MariaDB/server/blob/10.5/debian/additions/mariadb.conf.d/50-server.cnf).

In mysql_install_db, `skip-log-bin` means that adding `expire-logs-days` is harmless. In `docker_temp_server_start`, we are aren't in an online mode, so we are either initializing, or mariadb-upgrade. Even if the temporary start takes long than 10 or more days, it makes little sense to expire those. The real expire-log-days is configured in the final startup, which at least give replication at chance to grab those files before expiry.

Closes: #425

Notably this doesn't remove the warning from the final MariaDB startup. To do so would have mean pulling the `log-bin` and `expire-logs-days` and `binlog-expire-logs-seconds` settings to see if an invalid combination occurred and the passing `--expire-logs-days=0` as args. I didn't want to introduce that complexity. Maybe the server warning could be downgraded to a note.