### PR TITLE
Fixed image failing to build

### DIFF
--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -76,10 +76,14 @@ RUN set -ex; \
 	apt-key list
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le
+## Change this
+ARG MARIADB_PASSWORD='your_password'
+
 ARG MARIADB_MAJOR=10.2
 ENV MARIADB_MAJOR $MARIADB_MAJOR
 ARG MARIADB_VERSION=1:10.2.43+maria~bionic
 ENV MARIADB_VERSION $MARIADB_VERSION
+ENV MARIADB_ROOT_PASSWORD=$MARIADB_PASSWORD
 # release-status:Stable
 # (https://downloads.mariadb.org/mariadb/+releases/)
 

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -133,10 +133,18 @@ RUN set -ex; \
 
 VOLUME /var/lib/mysql
 
-COPY healthcheck.sh /usr/local/bin/healthcheck.sh
-COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
-ENTRYPOINT ["docker-entrypoint.sh"]
+RUN apt update && apt install wget -y
+
+RUN cd /home; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/healthcheck.sh; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/docker-entrypoint.sh
+
+RUN chmod -R 777 /home
+
+RUN cp /home/healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN cp /home/docker-entrypoint.sh /usr/local/bin/
+RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
+ENTRYPOINT ["/home/docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mysqld"]

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -133,10 +133,18 @@ RUN set -ex; \
 
 VOLUME /var/lib/mysql
 
-COPY healthcheck.sh /usr/local/bin/healthcheck.sh
-COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
-ENTRYPOINT ["docker-entrypoint.sh"]
+RUN apt update && apt install wget -y
+
+RUN cd /home; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/healthcheck.sh; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/docker-entrypoint.sh
+
+RUN chmod -R 777 /home
+
+RUN cp /home/healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN cp /home/docker-entrypoint.sh /usr/local/bin/
+RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
+ENTRYPOINT ["/home/docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mysqld"]

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -76,10 +76,14 @@ RUN set -ex; \
 	apt-key list
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le
+## Change this
+ARG MARIADB_PASSWORD='your_password'
+
 ARG MARIADB_MAJOR=10.3
 ENV MARIADB_MAJOR $MARIADB_MAJOR
 ARG MARIADB_VERSION=1:10.3.34+maria~focal
 ENV MARIADB_VERSION $MARIADB_VERSION
+ENV MARIADB_ROOT_PASSWORD=$MARIADB_PASSWORD
 # release-status:Stable
 # (https://downloads.mariadb.org/mariadb/+releases/)
 

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -133,10 +133,18 @@ RUN set -ex; \
 
 VOLUME /var/lib/mysql
 
-COPY healthcheck.sh /usr/local/bin/healthcheck.sh
-COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
-ENTRYPOINT ["docker-entrypoint.sh"]
+RUN apt update && apt install wget -y
+
+RUN cd /home; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/healthcheck.sh; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/docker-entrypoint.sh
+
+RUN chmod -R 777 /home
+
+RUN cp /home/healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN cp /home/docker-entrypoint.sh /usr/local/bin/
+RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
+ENTRYPOINT ["/home/docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mysqld"]

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -76,10 +76,14 @@ RUN set -ex; \
 	apt-key list
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le
+## Change this
+ARG MARIADB_PASSWORD='your_password'
+
 ARG MARIADB_MAJOR=10.4
 ENV MARIADB_MAJOR $MARIADB_MAJOR
 ARG MARIADB_VERSION=1:10.4.24+maria~focal
 ENV MARIADB_VERSION $MARIADB_VERSION
+ENV MARIADB_ROOT_PASSWORD=$MARIADB_PASSWORD
 # release-status:Stable
 # (https://downloads.mariadb.org/mariadb/+releases/)
 

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -76,10 +76,14 @@ RUN set -ex; \
 	apt-key list
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le s390x
+## Change this
+ARG MARIADB_PASSWORD='your_password'
+
 ARG MARIADB_MAJOR=10.5
 ENV MARIADB_MAJOR $MARIADB_MAJOR
 ARG MARIADB_VERSION=1:10.5.15+maria~focal
 ENV MARIADB_VERSION $MARIADB_VERSION
+ENV MARIADB_ROOT_PASSWORD=$MARIADB_PASSWORD
 # release-status:Stable
 # (https://downloads.mariadb.org/mariadb/+releases/)
 

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -133,9 +133,17 @@ RUN set -ex; \
 
 VOLUME /var/lib/mysql
 
-COPY healthcheck.sh /usr/local/bin/healthcheck.sh
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+RUN apt update && apt install wget -y
+
+RUN cd /home; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/healthcheck.sh; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/docker-entrypoint.sh
+
+RUN chmod -R 777 /home
+
+RUN cp /home/healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN cp /home/docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["/home/docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mysqld"]

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -76,10 +76,14 @@ RUN set -ex; \
 	apt-key list
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le s390x
+## Change this
+ARG MARIADB_PASSWORD='your_password'
+
 ARG MARIADB_MAJOR=10.6
 ENV MARIADB_MAJOR $MARIADB_MAJOR
 ARG MARIADB_VERSION=1:10.6.7+maria~focal
 ENV MARIADB_VERSION $MARIADB_VERSION
+ENV MARIADB_ROOT_PASSWORD=$MARIADB_PASSWORD
 # release-status:Stable
 # (https://downloads.mariadb.org/mariadb/+releases/)
 

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -133,9 +133,17 @@ RUN set -ex; \
 
 VOLUME /var/lib/mysql
 
-COPY healthcheck.sh /usr/local/bin/healthcheck.sh
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+RUN apt update && apt install wget -y
+
+RUN cd /home; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/healthcheck.sh; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/docker-entrypoint.sh
+
+RUN chmod -R 777 /home
+
+RUN cp /home/healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN cp /home/docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["/home/docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/10.7/Dockerfile
+++ b/10.7/Dockerfile
@@ -133,9 +133,17 @@ RUN set -ex; \
 
 VOLUME /var/lib/mysql
 
-COPY healthcheck.sh /usr/local/bin/healthcheck.sh
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+RUN apt update && apt install wget -y
+
+RUN cd /home; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/healthcheck.sh; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/docker-entrypoint.sh
+
+RUN chmod -R 777 /home
+
+RUN cp /home/healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN cp /home/docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["/home/docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/10.7/Dockerfile
+++ b/10.7/Dockerfile
@@ -76,10 +76,14 @@ RUN set -ex; \
 	apt-key list
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le s390x
+## Change this
+ARG MARIADB_PASSWORD='your_password'
+
 ARG MARIADB_MAJOR=10.7
 ENV MARIADB_MAJOR $MARIADB_MAJOR
 ARG MARIADB_VERSION=1:10.7.3+maria~focal
 ENV MARIADB_VERSION $MARIADB_VERSION
+ENV MARIADB_ROOT_PASSWORD=$MARIADB_PASSWORD
 # release-status:Stable
 # (https://downloads.mariadb.org/mariadb/+releases/)
 

--- a/10.8/Dockerfile
+++ b/10.8/Dockerfile
@@ -133,9 +133,17 @@ RUN set -ex; \
 
 VOLUME /var/lib/mysql
 
-COPY healthcheck.sh /usr/local/bin/healthcheck.sh
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+RUN apt update && apt install wget -y
+
+RUN cd /home; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/healthcheck.sh; \
+	wget https://raw.githubusercontent.com/MariaDB/mariadb-docker/db55d2702dfc0102364a29ab00334b6a02085ef9/10.8/docker-entrypoint.sh
+
+RUN chmod -R 777 /home
+
+RUN cp /home/healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN cp /home/docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["/home/docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/10.8/Dockerfile
+++ b/10.8/Dockerfile
@@ -76,10 +76,14 @@ RUN set -ex; \
 	apt-key list
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le s390x
+## Change this
+ARG MARIADB_PASSWORD='your_password'
+
 ARG MARIADB_MAJOR=10.8
 ENV MARIADB_MAJOR $MARIADB_MAJOR
 ARG MARIADB_VERSION=1:10.8.2+maria~focal
 ENV MARIADB_VERSION $MARIADB_VERSION
+ENV MARIADB_ROOT_PASSWORD=$MARIADB_PASSWORD
 # release-status:RC
 # (https://downloads.mariadb.org/mariadb/+releases/)
 


### PR DESCRIPTION
Without this, the files docker-entrypoint.sh and healthcheck.sh were reported as missing! This update installs wget, which downloads the two files! Since

```dockerfile
COPY
```

only recognizes /home as home, which of course leads to errors, I replaced this with

```dockerfile
RUN cp
```

which works!