### PR TITLE
MDEV-28263: mysql_tzinfo_to_sql simplified

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -268,19 +268,11 @@ docker_sql_escape_string_literal() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MARIADB_INITDB_SKIP_TZINFO" ]; then
-		{
-			# MDEV-28189 Replicating the tzinfo is a slow.
-			# Its quicker if replicas just initialize the same way.
-			echo "SELECT @@SQL_LOG_BIN INTO @save_sql_log_bin;
-				SET SESSION SQL_LOG_BIN=0;"
-
-			# --skip-write-binlog here is only if Galera is detected
-			# but usefully outputs LOCK TABLES to improve the IO of
-			# Aria (MDEV-23326).
-			mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo
-
-			echo "SET SESSION SQL_LOG_BIN=@save_sql_log_bin;"
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# --skip-write-binlog usefully disables binary logging
+		# but also outputs LOCK TABLES to improve the IO of
+		# Aria (MDEV-23326) for 10.4+.
+		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -268,19 +268,11 @@ docker_sql_escape_string_literal() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MARIADB_INITDB_SKIP_TZINFO" ]; then
-		{
-			# MDEV-28189 Replicating the tzinfo is a slow.
-			# Its quicker if replicas just initialize the same way.
-			echo "SELECT @@SQL_LOG_BIN INTO @save_sql_log_bin;
-				SET SESSION SQL_LOG_BIN=0;"
-
-			# --skip-write-binlog here is only if Galera is detected
-			# but usefully outputs LOCK TABLES to improve the IO of
-			# Aria (MDEV-23326).
-			mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo
-
-			echo "SET SESSION SQL_LOG_BIN=@save_sql_log_bin;"
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# --skip-write-binlog usefully disables binary logging
+		# but also outputs LOCK TABLES to improve the IO of
+		# Aria (MDEV-23326) for 10.4+.
+		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -268,19 +268,11 @@ docker_sql_escape_string_literal() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MARIADB_INITDB_SKIP_TZINFO" ]; then
-		{
-			# MDEV-28189 Replicating the tzinfo is a slow.
-			# Its quicker if replicas just initialize the same way.
-			echo "SELECT @@SQL_LOG_BIN INTO @save_sql_log_bin;
-				SET SESSION SQL_LOG_BIN=0;"
-
-			# --skip-write-binlog here is only if Galera is detected
-			# but usefully outputs LOCK TABLES to improve the IO of
-			# Aria (MDEV-23326).
-			mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo
-
-			echo "SET SESSION SQL_LOG_BIN=@save_sql_log_bin;"
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# --skip-write-binlog usefully disables binary logging
+		# but also outputs LOCK TABLES to improve the IO of
+		# Aria (MDEV-23326) for 10.4+.
+		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -268,19 +268,11 @@ docker_sql_escape_string_literal() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MARIADB_INITDB_SKIP_TZINFO" ]; then
-		{
-			# MDEV-28189 Replicating the tzinfo is a slow.
-			# Its quicker if replicas just initialize the same way.
-			echo "SELECT @@SQL_LOG_BIN INTO @save_sql_log_bin;
-				SET SESSION SQL_LOG_BIN=0;"
-
-			# --skip-write-binlog here is only if Galera is detected
-			# but usefully outputs LOCK TABLES to improve the IO of
-			# Aria (MDEV-23326).
-			mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo
-
-			echo "SET SESSION SQL_LOG_BIN=@save_sql_log_bin;"
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# --skip-write-binlog usefully disables binary logging
+		# but also outputs LOCK TABLES to improve the IO of
+		# Aria (MDEV-23326) for 10.4+.
+		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -268,19 +268,11 @@ docker_sql_escape_string_literal() {
 docker_setup_db() {
 	# Load timezone info into database
 	if [ -z "$MARIADB_INITDB_SKIP_TZINFO" ]; then
-		{
-			# MDEV-28189 Replicating the tzinfo is a slow.
-			# Its quicker if replicas just initialize the same way.
-			echo "SELECT @@SQL_LOG_BIN INTO @save_sql_log_bin;
-				SET SESSION SQL_LOG_BIN=0;"
-
-			# --skip-write-binlog here is only if Galera is detected
-			# but usefully outputs LOCK TABLES to improve the IO of
-			# Aria (MDEV-23326).
-			mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo
-
-			echo "SET SESSION SQL_LOG_BIN=@save_sql_log_bin;"
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		# --skip-write-binlog usefully disables binary logging
+		# but also outputs LOCK TABLES to improve the IO of
+		# Aria (MDEV-23326) for 10.4+.
+		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password


### PR DESCRIPTION
With [MDEV-28263](https://jira.mariadb.org/browse/MDEV-28263) implementing --skip-write-binlog meaning skip writing to the binary log as well as the save and restore (10.6+) (not like it matters too much on a non-shared connection).