### PR TITLE
MARIADB_DISABLE_UPGRADE_BACKUP to take non-empty value

### DIFF
--- a/10.10/docker-entrypoint.sh
+++ b/10.10/docker-entrypoint.sh
@@ -360,9 +360,8 @@ docker_setup_db() {
 # backup the mysql database
 docker_mariadb_backup_system()
 {
-	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ] \
-		&& [ "$MARIADB_DISABLE_UPGRADE_BACKUP" = 1 ]; then
-		mysql_note "MariaDB upgrade backup disabled due to \$MARIADB_DISABLE_UPGRADE_BACKUP=1 setting"
+	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ]; then
+		mysql_note "MariaDB upgrade backup disabled due to non-empty \$MARIADB_DISABLE_UPGRADE_BACKUP setting"
 		return
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -360,9 +360,8 @@ docker_setup_db() {
 # backup the mysql database
 docker_mariadb_backup_system()
 {
-	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ] \
-		&& [ "$MARIADB_DISABLE_UPGRADE_BACKUP" = 1 ]; then
-		mysql_note "MariaDB upgrade backup disabled due to \$MARIADB_DISABLE_UPGRADE_BACKUP=1 setting"
+	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ]; then
+		mysql_note "MariaDB upgrade backup disabled due to non-empty \$MARIADB_DISABLE_UPGRADE_BACKUP setting"
 		return
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -360,9 +360,8 @@ docker_setup_db() {
 # backup the mysql database
 docker_mariadb_backup_system()
 {
-	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ] \
-		&& [ "$MARIADB_DISABLE_UPGRADE_BACKUP" = 1 ]; then
-		mysql_note "MariaDB upgrade backup disabled due to \$MARIADB_DISABLE_UPGRADE_BACKUP=1 setting"
+	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ]; then
+		mysql_note "MariaDB upgrade backup disabled due to non-empty \$MARIADB_DISABLE_UPGRADE_BACKUP setting"
 		return
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -360,9 +360,8 @@ docker_setup_db() {
 # backup the mysql database
 docker_mariadb_backup_system()
 {
-	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ] \
-		&& [ "$MARIADB_DISABLE_UPGRADE_BACKUP" = 1 ]; then
-		mysql_note "MariaDB upgrade backup disabled due to \$MARIADB_DISABLE_UPGRADE_BACKUP=1 setting"
+	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ]; then
+		mysql_note "MariaDB upgrade backup disabled due to non-empty \$MARIADB_DISABLE_UPGRADE_BACKUP setting"
 		return
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -360,9 +360,8 @@ docker_setup_db() {
 # backup the mysql database
 docker_mariadb_backup_system()
 {
-	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ] \
-		&& [ "$MARIADB_DISABLE_UPGRADE_BACKUP" = 1 ]; then
-		mysql_note "MariaDB upgrade backup disabled due to \$MARIADB_DISABLE_UPGRADE_BACKUP=1 setting"
+	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ]; then
+		mysql_note "MariaDB upgrade backup disabled due to non-empty \$MARIADB_DISABLE_UPGRADE_BACKUP setting"
 		return
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"

--- a/10.7/docker-entrypoint.sh
+++ b/10.7/docker-entrypoint.sh
@@ -360,9 +360,8 @@ docker_setup_db() {
 # backup the mysql database
 docker_mariadb_backup_system()
 {
-	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ] \
-		&& [ "$MARIADB_DISABLE_UPGRADE_BACKUP" = 1 ]; then
-		mysql_note "MariaDB upgrade backup disabled due to \$MARIADB_DISABLE_UPGRADE_BACKUP=1 setting"
+	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ]; then
+		mysql_note "MariaDB upgrade backup disabled due to non-empty \$MARIADB_DISABLE_UPGRADE_BACKUP setting"
 		return
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"

--- a/10.8/docker-entrypoint.sh
+++ b/10.8/docker-entrypoint.sh
@@ -360,9 +360,8 @@ docker_setup_db() {
 # backup the mysql database
 docker_mariadb_backup_system()
 {
-	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ] \
-		&& [ "$MARIADB_DISABLE_UPGRADE_BACKUP" = 1 ]; then
-		mysql_note "MariaDB upgrade backup disabled due to \$MARIADB_DISABLE_UPGRADE_BACKUP=1 setting"
+	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ]; then
+		mysql_note "MariaDB upgrade backup disabled due to non-empty \$MARIADB_DISABLE_UPGRADE_BACKUP setting"
 		return
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"

--- a/10.9/docker-entrypoint.sh
+++ b/10.9/docker-entrypoint.sh
@@ -360,9 +360,8 @@ docker_setup_db() {
 # backup the mysql database
 docker_mariadb_backup_system()
 {
-	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ] \
-		&& [ "$MARIADB_DISABLE_UPGRADE_BACKUP" = 1 ]; then
-		mysql_note "MariaDB upgrade backup disabled due to \$MARIADB_DISABLE_UPGRADE_BACKUP=1 setting"
+	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ]; then
+		mysql_note "MariaDB upgrade backup disabled due to non-empty \$MARIADB_DISABLE_UPGRADE_BACKUP setting"
 		return
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -360,9 +360,8 @@ docker_setup_db() {
 # backup the mysql database
 docker_mariadb_backup_system()
 {
-	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ] \
-		&& [ "$MARIADB_DISABLE_UPGRADE_BACKUP" = 1 ]; then
-		mysql_note "MariaDB upgrade backup disabled due to \$MARIADB_DISABLE_UPGRADE_BACKUP=1 setting"
+	if [ -n "$MARIADB_DISABLE_UPGRADE_BACKUP" ]; then
+		mysql_note "MariaDB upgrade backup disabled due to non-empty \$MARIADB_DISABLE_UPGRADE_BACKUP setting"
 		return
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"


### PR DESCRIPTION
Like all the other environment variables.

Closes #441.

@mirekphd is this what you where expecting?

I'm not sure the string vs number comparison makes much difference, so this brings it back in line with the documents. I can't see in #350 why I added the ` = 1` test.