### PR TITLE
Improve security permissions in docker images

### DIFF
--- a/10.10/Dockerfile
+++ b/10.10/Dockerfile
@@ -126,5 +126,6 @@ COPY healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -129,5 +129,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mysqld"]

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -129,5 +129,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mysqld"]

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -128,5 +128,6 @@ COPY healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mysqld"]

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -128,5 +128,6 @@ COPY healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/10.7/Dockerfile
+++ b/10.7/Dockerfile
@@ -128,5 +128,6 @@ COPY healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/10.8/Dockerfile
+++ b/10.8/Dockerfile
@@ -128,5 +128,6 @@ COPY healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/10.9/Dockerfile
+++ b/10.9/Dockerfile
@@ -126,5 +126,6 @@ COPY healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -129,5 +129,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mysqld"]


### PR DESCRIPTION
According to docker best practises it is not recommended to run docker with root permissions. So it is better to use `mysql` user to run docker