### PR TITLE
Revert "MDEV-29347: sql-mode=ONLY_FULL_GROUP_BY work around for tzinfo"

### DIFF
--- a/10.10/docker-entrypoint.sh
+++ b/10.10/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.11/docker-entrypoint.sh
+++ b/10.11/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.3/docker-entrypoint.sh
+++ b/10.3/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.4/docker-entrypoint.sh
+++ b/10.4/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.7/docker-entrypoint.sh
+++ b/10.7/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.8/docker-entrypoint.sh
+++ b/10.8/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/10.9/docker-entrypoint.sh
+++ b/10.9/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -273,11 +273,8 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		{
-			# temporary fix for MDEV-29347 - ONLY_FULL_GROUP_BY incompatiblity
-			echo "SET @@SQL_MODE = REPLACE(@@SQL_MODE, 'ONLY_FULL_GROUP_BY', '');"
-			mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo
-		} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
 	# Generate random root password


### PR DESCRIPTION
This reverts commit fab7f4020790b233c03cb0ab0b0c9fd5483d66c5 as upstream bug MDEV-29347 is fixed.

test case part of above commit it kept however.