### PR TITLE
Add LANG=C.UTF-8 for those that exec in container

### DIFF
--- a/10.10/Dockerfile
+++ b/10.10/Dockerfile
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \

--- a/10.11/Dockerfile
+++ b/10.11/Dockerfile
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \

--- a/10.7/Dockerfile
+++ b/10.7/Dockerfile
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \

--- a/10.8/Dockerfile
+++ b/10.8/Dockerfile
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \

--- a/10.9/Dockerfile
+++ b/10.9/Dockerfile
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -76,6 +76,10 @@ RUN set -ex; \
 		:; \
 	fi
 
+# Ensure the container exec commands handle range of utf8 characters based of
+# default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)
+ENV LANG C.UTF-8
+
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \


### PR DESCRIPTION
Allows full UTF-8 characters to be processed.

Closes #468.