### PR TITLE
Reduce gpg packages in image

### DIFF
--- a/10.10/Dockerfile
+++ b/10.10/Dockerfile
@@ -4,22 +4,31 @@ FROM ubuntu:jammy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)

--- a/10.11/Dockerfile
+++ b/10.11/Dockerfile
@@ -4,22 +4,31 @@ FROM ubuntu:jammy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -4,22 +4,31 @@ FROM ubuntu:focal
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -4,22 +4,31 @@ FROM ubuntu:focal
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -4,22 +4,31 @@ FROM ubuntu:focal
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -4,22 +4,31 @@ FROM ubuntu:focal
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)

--- a/10.7/Dockerfile
+++ b/10.7/Dockerfile
@@ -4,22 +4,31 @@ FROM ubuntu:focal
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)

--- a/10.8/Dockerfile
+++ b/10.8/Dockerfile
@@ -4,22 +4,31 @@ FROM ubuntu:jammy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)

--- a/10.9/Dockerfile
+++ b/10.9/Dockerfile
@@ -4,22 +4,31 @@ FROM ubuntu:jammy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,22 +4,31 @@ FROM ubuntu:%%SUITE%%
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -ex; \
-	apt-get update; \
-	if ! which gpg; then \
-		apt-get install -y --no-install-recommends gnupg; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*
-
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
+# gosu key is B42F6819007F00F88E364FD4036A9C25BF357DD4
 ENV GOSU_VERSION 1.14
-# apt-mark manual "$savedAptMark" does not work
+
+ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
+# pub   rsa4096 2016-03-30 [SC]
+#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
+# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
+# sub   rsa4096 2016-03-30 [E]
+# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
+# install "pwgen" for randomizing passwords
+# install "tzdata" for /usr/share/zoneinfo/
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
 # hadolint ignore=SC2086
 RUN set -eux; \
 	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+		gpg gpgv dirmngr gpg-agent \
+		libjemalloc2 \
+		pwgen \
+		tzdata \
+		xz-utils \
+		zstd ; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -29,52 +38,25 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; \
 	export GNUPGHOME; \
 	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-# install "libjemalloc2" as it offers better performance in some cases. Use with LD_PRELOAD
-# install "pwgen" for randomizing passwords
-# install "tzdata" for /usr/share/zoneinfo/
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
-# install "zstd" for .sql.zst docker-entrypoint-initdb.d files
-RUN set -ex; \
-	apt-get update; \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-		libjemalloc2 \
-		pwgen \
-		tzdata \
-		xz-utils \
-		zstd \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-ARG GPG_KEYS=177F4010FE56CA3336300305F1656F24C74CD1D8
-# pub   rsa4096 2016-03-30 [SC]
-#         177F 4010 FE56 CA33 3630  0305 F165 6F24 C74C D1D8
-# uid           [ unknown] MariaDB Signing Key <signing-key@mariadb.org>
-# sub   rsa4096 2016-03-30 [E]
-
-RUN set -ex; \
-	GNUPGHOME="$(mktemp -d)"; \
-	export GNUPGHOME; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export "$GPG_KEYS" > /etc/apt/trusted.gpg.d/mariadb.gpg; \
 	if command -v gpgconf >/dev/null; then \
 		gpgconf --kill all; \
-	else \
-		:; \
-	fi
+	fi ; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get remove -y dirmngr gpg-agent ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 # Ensure the container exec commands handle range of utf8 characters based of
 # default locales in base image (https://github.com/docker-library/docs/blob/135b79cc8093ab02e55debb61fdb079ab2dbce87/ubuntu/README.md#locales)


### PR DESCRIPTION
Especially removes libksba8 due to CVE-2022-3515
but generally reduction of build only dependencies is a good thing.

Closes: #469