### PR TITLE
Update GitHub Actions to use new bashbrew action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,13 @@ jobs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
       - uses: actions/checkout@v3
+      - uses: docker-library/bashbrew@v0.1.5
       - id: generate-jobs
         name: Generate Jobs
         run: |
-          git clone --depth 1 https://github.com/docker-library/bashbrew.git -b master ~/bashbrew
-          strategy="$(~/bashbrew/scripts/github-actions/generate.sh | jq -c '.matrix.include |= map(.meta.entries[0].tags[0] as $tag | select(.name != "10.9-jammy") | .runs.mariadbtest = "./.test/run.sh " + $tag)')"
+          strategy="$(GITHUB_REPOSITORY='mariadb' "$BASHBREW_SCRIPTS/github-actions/generate.sh" | jq -c '.matrix.include |= map(.meta.entries[0].tags[0] as $tag | select(.name != "10.9-jammy") | .runs.mariadbtest = "./.test/run.sh " + $tag)')"
+          echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
           jq . <<<"$strategy" # sanity check / debugging aid
-          echo "::set-output name=strategy::$strategy"
 
   test:
     needs: generate-jobs


### PR DESCRIPTION
This should fix errors that the old code would've run into thanks to the update to Go 1.18, and should help prevent them in the future by pinning to a specific release of both Bashbrew and the related scripts.

See also docker-library/bashbrew#57