### PR TITLE
Allow healthcheck_connect@{127.0.0.1,::1} to exist to facilitate healthcheck --connect

### DIFF
--- a/10.10/docker-entrypoint.sh
+++ b/10.10/docker-entrypoint.sh
@@ -226,9 +226,10 @@ docker_init_database_dir() {
 # This should be called after mysql_check_config, but before any other functions
 docker_setup_env() {
 	# Get config
-	declare -g DATADIR SOCKET
+	declare -g DATADIR SOCKET PORT
 	DATADIR="$(mysql_get_config 'datadir' "$@")"
 	SOCKET="$(mysql_get_config 'socket' "$@")"
+	PORT="$(mysql_get_config 'port' "$@")"
 
 
 	# Initialize values that might be stored in a file
@@ -364,6 +365,29 @@ docker_setup_db() {
 		fi
 	fi
 
+	local healthCheckUser
+	local healthCheckGrant=USAGE
+	local healthCheckConnectPass
+	local healthCheckConnectPassEscaped
+	healthCheckConnectPass="$(pwgen --numerals --capitalize --symbols --remove-chars="=#'\\" -1 32)"
+	healthCheckConnectPassEscaped=$( docker_sql_escape_string_literal "${healthCheckConnectPass}" )
+	if [ -n "$MARIADB_HEALTHCHECK_GRANTS" ]; then
+		healthCheckGrant="$MARIADB_HEALTHCHECK_GRANTS"
+	fi
+	read -r -d '' healthCheckUser <<-EOSQL || true
+	CREATE USER healthcheck@'127.0.0.1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@'::1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@localhost IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'127.0.0.1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'::1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@localhost;
+	EOSQL
+	local maskPreserve
+	maskPreserve=$(umask -p)
+	umask 0077
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	$maskPreserve
+
 	local rootLocalhostPass=
 	if [ -z "$MARIADB_ROOT_PASSWORD_HASH" ]; then
 		# handle MARIADB_ROOT_PASSWORD_HASH for root@localhost after /docker-entrypoint-initdb.d
@@ -433,6 +457,7 @@ docker_setup_db() {
 		${rootCreate}
 		${mysqlAtLocalhost}
 		${mysqlAtLocalhostGrants}
+		${healthCheckUser}
 		-- end of securing system users, rest of init now...
 		SET @@SESSION.SQL_LOG_BIN=@orig_sql_log_bin;
 		-- create users/databases

--- a/10.10/healthcheck.sh
+++ b/10.10/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {

--- a/10.11/docker-entrypoint.sh
+++ b/10.11/docker-entrypoint.sh
@@ -226,9 +226,10 @@ docker_init_database_dir() {
 # This should be called after mysql_check_config, but before any other functions
 docker_setup_env() {
 	# Get config
-	declare -g DATADIR SOCKET
+	declare -g DATADIR SOCKET PORT
 	DATADIR="$(mysql_get_config 'datadir' "$@")"
 	SOCKET="$(mysql_get_config 'socket' "$@")"
+	PORT="$(mysql_get_config 'port' "$@")"
 
 
 	# Initialize values that might be stored in a file
@@ -364,6 +365,29 @@ docker_setup_db() {
 		fi
 	fi
 
+	local healthCheckUser
+	local healthCheckGrant=USAGE
+	local healthCheckConnectPass
+	local healthCheckConnectPassEscaped
+	healthCheckConnectPass="$(pwgen --numerals --capitalize --symbols --remove-chars="=#'\\" -1 32)"
+	healthCheckConnectPassEscaped=$( docker_sql_escape_string_literal "${healthCheckConnectPass}" )
+	if [ -n "$MARIADB_HEALTHCHECK_GRANTS" ]; then
+		healthCheckGrant="$MARIADB_HEALTHCHECK_GRANTS"
+	fi
+	read -r -d '' healthCheckUser <<-EOSQL || true
+	CREATE USER healthcheck@'127.0.0.1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@'::1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@localhost IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'127.0.0.1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'::1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@localhost;
+	EOSQL
+	local maskPreserve
+	maskPreserve=$(umask -p)
+	umask 0077
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	$maskPreserve
+
 	local rootLocalhostPass=
 	if [ -z "$MARIADB_ROOT_PASSWORD_HASH" ]; then
 		# handle MARIADB_ROOT_PASSWORD_HASH for root@localhost after /docker-entrypoint-initdb.d
@@ -433,6 +457,7 @@ docker_setup_db() {
 		${rootCreate}
 		${mysqlAtLocalhost}
 		${mysqlAtLocalhostGrants}
+		${healthCheckUser}
 		-- end of securing system users, rest of init now...
 		SET @@SESSION.SQL_LOG_BIN=@orig_sql_log_bin;
 		-- create users/databases

--- a/10.11/healthcheck.sh
+++ b/10.11/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {

--- a/10.4/healthcheck.sh
+++ b/10.4/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mysql ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {

--- a/10.5/healthcheck.sh
+++ b/10.5/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mysql ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -226,9 +226,10 @@ docker_init_database_dir() {
 # This should be called after mysql_check_config, but before any other functions
 docker_setup_env() {
 	# Get config
-	declare -g DATADIR SOCKET
+	declare -g DATADIR SOCKET PORT
 	DATADIR="$(mysql_get_config 'datadir' "$@")"
 	SOCKET="$(mysql_get_config 'socket' "$@")"
+	PORT="$(mysql_get_config 'port' "$@")"
 
 
 	# Initialize values that might be stored in a file
@@ -364,6 +365,29 @@ docker_setup_db() {
 		fi
 	fi
 
+	local healthCheckUser
+	local healthCheckGrant=USAGE
+	local healthCheckConnectPass
+	local healthCheckConnectPassEscaped
+	healthCheckConnectPass="$(pwgen --numerals --capitalize --symbols --remove-chars="=#'\\" -1 32)"
+	healthCheckConnectPassEscaped=$( docker_sql_escape_string_literal "${healthCheckConnectPass}" )
+	if [ -n "$MARIADB_HEALTHCHECK_GRANTS" ]; then
+		healthCheckGrant="$MARIADB_HEALTHCHECK_GRANTS"
+	fi
+	read -r -d '' healthCheckUser <<-EOSQL || true
+	CREATE USER healthcheck@'127.0.0.1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@'::1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@localhost IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'127.0.0.1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'::1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@localhost;
+	EOSQL
+	local maskPreserve
+	maskPreserve=$(umask -p)
+	umask 0077
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	$maskPreserve
+
 	local rootLocalhostPass=
 	if [ -z "$MARIADB_ROOT_PASSWORD_HASH" ]; then
 		# handle MARIADB_ROOT_PASSWORD_HASH for root@localhost after /docker-entrypoint-initdb.d
@@ -433,6 +457,7 @@ docker_setup_db() {
 		${rootCreate}
 		${mysqlAtLocalhost}
 		${mysqlAtLocalhostGrants}
+		${healthCheckUser}
 		-- end of securing system users, rest of init now...
 		SET @@SESSION.SQL_LOG_BIN=@orig_sql_log_bin;
 		-- create users/databases

--- a/10.6/healthcheck.sh
+++ b/10.6/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {

--- a/10.9/docker-entrypoint.sh
+++ b/10.9/docker-entrypoint.sh
@@ -226,9 +226,10 @@ docker_init_database_dir() {
 # This should be called after mysql_check_config, but before any other functions
 docker_setup_env() {
 	# Get config
-	declare -g DATADIR SOCKET
+	declare -g DATADIR SOCKET PORT
 	DATADIR="$(mysql_get_config 'datadir' "$@")"
 	SOCKET="$(mysql_get_config 'socket' "$@")"
+	PORT="$(mysql_get_config 'port' "$@")"
 
 
 	# Initialize values that might be stored in a file
@@ -364,6 +365,29 @@ docker_setup_db() {
 		fi
 	fi
 
+	local healthCheckUser
+	local healthCheckGrant=USAGE
+	local healthCheckConnectPass
+	local healthCheckConnectPassEscaped
+	healthCheckConnectPass="$(pwgen --numerals --capitalize --symbols --remove-chars="=#'\\" -1 32)"
+	healthCheckConnectPassEscaped=$( docker_sql_escape_string_literal "${healthCheckConnectPass}" )
+	if [ -n "$MARIADB_HEALTHCHECK_GRANTS" ]; then
+		healthCheckGrant="$MARIADB_HEALTHCHECK_GRANTS"
+	fi
+	read -r -d '' healthCheckUser <<-EOSQL || true
+	CREATE USER healthcheck@'127.0.0.1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@'::1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@localhost IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'127.0.0.1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'::1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@localhost;
+	EOSQL
+	local maskPreserve
+	maskPreserve=$(umask -p)
+	umask 0077
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	$maskPreserve
+
 	local rootLocalhostPass=
 	if [ -z "$MARIADB_ROOT_PASSWORD_HASH" ]; then
 		# handle MARIADB_ROOT_PASSWORD_HASH for root@localhost after /docker-entrypoint-initdb.d
@@ -433,6 +457,7 @@ docker_setup_db() {
 		${rootCreate}
 		${mysqlAtLocalhost}
 		${mysqlAtLocalhostGrants}
+		${healthCheckUser}
 		-- end of securing system users, rest of init now...
 		SET @@SESSION.SQL_LOG_BIN=@orig_sql_log_bin;
 		-- create users/databases

--- a/10.9/healthcheck.sh
+++ b/10.9/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {

--- a/11.0/docker-entrypoint.sh
+++ b/11.0/docker-entrypoint.sh
@@ -226,9 +226,10 @@ docker_init_database_dir() {
 # This should be called after mysql_check_config, but before any other functions
 docker_setup_env() {
 	# Get config
-	declare -g DATADIR SOCKET
+	declare -g DATADIR SOCKET PORT
 	DATADIR="$(mysql_get_config 'datadir' "$@")"
 	SOCKET="$(mysql_get_config 'socket' "$@")"
+	PORT="$(mysql_get_config 'port' "$@")"
 
 
 	# Initialize values that might be stored in a file
@@ -364,6 +365,29 @@ docker_setup_db() {
 		fi
 	fi
 
+	local healthCheckUser
+	local healthCheckGrant=USAGE
+	local healthCheckConnectPass
+	local healthCheckConnectPassEscaped
+	healthCheckConnectPass="$(pwgen --numerals --capitalize --symbols --remove-chars="=#'\\" -1 32)"
+	healthCheckConnectPassEscaped=$( docker_sql_escape_string_literal "${healthCheckConnectPass}" )
+	if [ -n "$MARIADB_HEALTHCHECK_GRANTS" ]; then
+		healthCheckGrant="$MARIADB_HEALTHCHECK_GRANTS"
+	fi
+	read -r -d '' healthCheckUser <<-EOSQL || true
+	CREATE USER healthcheck@'127.0.0.1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@'::1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@localhost IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'127.0.0.1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'::1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@localhost;
+	EOSQL
+	local maskPreserve
+	maskPreserve=$(umask -p)
+	umask 0077
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	$maskPreserve
+
 	local rootLocalhostPass=
 	if [ -z "$MARIADB_ROOT_PASSWORD_HASH" ]; then
 		# handle MARIADB_ROOT_PASSWORD_HASH for root@localhost after /docker-entrypoint-initdb.d
@@ -433,6 +457,7 @@ docker_setup_db() {
 		${rootCreate}
 		${mysqlAtLocalhost}
 		${mysqlAtLocalhostGrants}
+		${healthCheckUser}
 		-- end of securing system users, rest of init now...
 		SET @@SESSION.SQL_LOG_BIN=@orig_sql_log_bin;
 		-- create users/databases

--- a/11.0/healthcheck.sh
+++ b/11.0/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {

--- a/11.1/docker-entrypoint.sh
+++ b/11.1/docker-entrypoint.sh
@@ -226,9 +226,10 @@ docker_init_database_dir() {
 # This should be called after mysql_check_config, but before any other functions
 docker_setup_env() {
 	# Get config
-	declare -g DATADIR SOCKET
+	declare -g DATADIR SOCKET PORT
 	DATADIR="$(mysql_get_config 'datadir' "$@")"
 	SOCKET="$(mysql_get_config 'socket' "$@")"
+	PORT="$(mysql_get_config 'port' "$@")"
 
 
 	# Initialize values that might be stored in a file
@@ -364,6 +365,29 @@ docker_setup_db() {
 		fi
 	fi
 
+	local healthCheckUser
+	local healthCheckGrant=USAGE
+	local healthCheckConnectPass
+	local healthCheckConnectPassEscaped
+	healthCheckConnectPass="$(pwgen --numerals --capitalize --symbols --remove-chars="=#'\\" -1 32)"
+	healthCheckConnectPassEscaped=$( docker_sql_escape_string_literal "${healthCheckConnectPass}" )
+	if [ -n "$MARIADB_HEALTHCHECK_GRANTS" ]; then
+		healthCheckGrant="$MARIADB_HEALTHCHECK_GRANTS"
+	fi
+	read -r -d '' healthCheckUser <<-EOSQL || true
+	CREATE USER healthcheck@'127.0.0.1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@'::1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@localhost IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'127.0.0.1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'::1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@localhost;
+	EOSQL
+	local maskPreserve
+	maskPreserve=$(umask -p)
+	umask 0077
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	$maskPreserve
+
 	local rootLocalhostPass=
 	if [ -z "$MARIADB_ROOT_PASSWORD_HASH" ]; then
 		# handle MARIADB_ROOT_PASSWORD_HASH for root@localhost after /docker-entrypoint-initdb.d
@@ -433,6 +457,7 @@ docker_setup_db() {
 		${rootCreate}
 		${mysqlAtLocalhost}
 		${mysqlAtLocalhostGrants}
+		${healthCheckUser}
 		-- end of securing system users, rest of init now...
 		SET @@SESSION.SQL_LOG_BIN=@orig_sql_log_bin;
 		-- create users/databases

--- a/11.1/healthcheck.sh
+++ b/11.1/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {

--- a/11.2/docker-entrypoint.sh
+++ b/11.2/docker-entrypoint.sh
@@ -226,9 +226,10 @@ docker_init_database_dir() {
 # This should be called after mysql_check_config, but before any other functions
 docker_setup_env() {
 	# Get config
-	declare -g DATADIR SOCKET
+	declare -g DATADIR SOCKET PORT
 	DATADIR="$(mysql_get_config 'datadir' "$@")"
 	SOCKET="$(mysql_get_config 'socket' "$@")"
+	PORT="$(mysql_get_config 'port' "$@")"
 
 
 	# Initialize values that might be stored in a file
@@ -364,6 +365,29 @@ docker_setup_db() {
 		fi
 	fi
 
+	local healthCheckUser
+	local healthCheckGrant=USAGE
+	local healthCheckConnectPass
+	local healthCheckConnectPassEscaped
+	healthCheckConnectPass="$(pwgen --numerals --capitalize --symbols --remove-chars="=#'\\" -1 32)"
+	healthCheckConnectPassEscaped=$( docker_sql_escape_string_literal "${healthCheckConnectPass}" )
+	if [ -n "$MARIADB_HEALTHCHECK_GRANTS" ]; then
+		healthCheckGrant="$MARIADB_HEALTHCHECK_GRANTS"
+	fi
+	read -r -d '' healthCheckUser <<-EOSQL || true
+	CREATE USER healthcheck@'127.0.0.1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@'::1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@localhost IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'127.0.0.1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'::1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@localhost;
+	EOSQL
+	local maskPreserve
+	maskPreserve=$(umask -p)
+	umask 0077
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	$maskPreserve
+
 	local rootLocalhostPass=
 	if [ -z "$MARIADB_ROOT_PASSWORD_HASH" ]; then
 		# handle MARIADB_ROOT_PASSWORD_HASH for root@localhost after /docker-entrypoint-initdb.d
@@ -433,6 +457,7 @@ docker_setup_db() {
 		${rootCreate}
 		${mysqlAtLocalhost}
 		${mysqlAtLocalhostGrants}
+		${healthCheckUser}
 		-- end of securing system users, rest of init now...
 		SET @@SESSION.SQL_LOG_BIN=@orig_sql_log_bin;
 		-- create users/databases

--- a/11.2/healthcheck.sh
+++ b/11.2/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -226,9 +226,10 @@ docker_init_database_dir() {
 # This should be called after mysql_check_config, but before any other functions
 docker_setup_env() {
 	# Get config
-	declare -g DATADIR SOCKET
+	declare -g DATADIR SOCKET PORT
 	DATADIR="$(mysql_get_config 'datadir' "$@")"
 	SOCKET="$(mysql_get_config 'socket' "$@")"
+	PORT="$(mysql_get_config 'port' "$@")"
 
 
 	# Initialize values that might be stored in a file
@@ -364,6 +365,29 @@ docker_setup_db() {
 		fi
 	fi
 
+	local healthCheckUser
+	local healthCheckGrant=USAGE
+	local healthCheckConnectPass
+	local healthCheckConnectPassEscaped
+	healthCheckConnectPass="$(pwgen --numerals --capitalize --symbols --remove-chars="=#'\\" -1 32)"
+	healthCheckConnectPassEscaped=$( docker_sql_escape_string_literal "${healthCheckConnectPass}" )
+	if [ -n "$MARIADB_HEALTHCHECK_GRANTS" ]; then
+		healthCheckGrant="$MARIADB_HEALTHCHECK_GRANTS"
+	fi
+	read -r -d '' healthCheckUser <<-EOSQL || true
+	CREATE USER healthcheck@'127.0.0.1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@'::1' IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	CREATE USER healthcheck@localhost IDENTIFIED BY '$healthCheckConnectPassEscaped';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'127.0.0.1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@'::1';
+	GRANT $healthCheckGrant ON *.* TO healthcheck@localhost;
+	EOSQL
+	local maskPreserve
+	maskPreserve=$(umask -p)
+	umask 0077
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	$maskPreserve
+
 	local rootLocalhostPass=
 	if [ -z "$MARIADB_ROOT_PASSWORD_HASH" ]; then
 		# handle MARIADB_ROOT_PASSWORD_HASH for root@localhost after /docker-entrypoint-initdb.d
@@ -433,6 +457,7 @@ docker_setup_db() {
 		${rootCreate}
 		${mysqlAtLocalhost}
 		${mysqlAtLocalhostGrants}
+		${healthCheckUser}
 		-- end of securing system users, rest of init now...
 		SET @@SESSION.SQL_LOG_BIN=@orig_sql_log_bin;
 		-- create users/databases

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -55,6 +55,8 @@ _process_sql()
 connect()
 {
 	set +e +o pipefail
+	# (on second extra_file)
+	# shellcheck disable=SC2086
 	mysql ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
@@ -210,6 +212,9 @@ declare -A repl
 declare -A def
 nodefaults=
 datadir=/var/lib/mysql
+if [ -f $datadir/.my-healthcheck.cnf ]; then
+	def['extra_file']=$datadir/.my-healthcheck.cnf
+fi
 
 _repl_param_check()
 {


### PR DESCRIPTION
Closes #430

@mmontes11, @gremo, @jerdoe, what do you think?

The grant on `mysql@::1` `mysql@127.0.0.1` is excessive to the TCP requirements, not used in other healthcheck tests. Original I was thinking of including them for consistency, but any objection if that is dropped?

tested with:

```
$ podman run --rm --env MARIADB_ROOT_PASSWORD=bob --env MARIADB_MYSQL_LOCALHOST_USER=1  --health-cmd='healthcheck.sh --su-mysql --connect' m106
2023-05-16 00:10:32+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.6.13+maria~ubu2004 started.
2023-05-16 00:10:32+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2023-05-16 00:10:32+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.6.13+maria~ubu2004 started.
2023-05-16 00:10:32+00:00 [Note] [Entrypoint]: Initializing database files
...
2023-05-16  0:10:35 0 [Warning] You need to use --log-bin to make --expire-logs-days or --binlog-expire-logs-seconds work.
2023-05-16  0:10:35 0 [Note] Server socket created on IP: '0.0.0.0'.
2023-05-16  0:10:35 0 [Note] Server socket created on IP: '::'.
2023-05-16  0:10:35 0 [Note] mariadbd: ready for connections.
Version: '10.6.13-MariaDB-1:10.6.13+maria~ubu2004'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
```