### PR TITLE
remove host-cache-size=0/skip-name-resolve

### DIFF
--- a/10.10/Dockerfile
+++ b/10.10/Dockerfile
@@ -121,8 +121,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/10.11/Dockerfile
+++ b/10.11/Dockerfile
@@ -121,8 +121,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -123,8 +123,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -123,8 +123,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -123,8 +123,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/10.9/Dockerfile
+++ b/10.9/Dockerfile
@@ -121,8 +121,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -121,8 +121,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/11.1/Dockerfile
+++ b/11.1/Dockerfile
@@ -121,8 +121,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/11.2/Dockerfile
+++ b/11.2/Dockerfile
@@ -121,8 +121,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -123,8 +123,6 @@ RUN set -ex; \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
-# don't reverse lookup hostnames, they are usually another container
-	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+


### PR DESCRIPTION
Container environment can depend on a HOSTNAME of
the source container being resolvable. The resolution is cached so shouldn't be an impact.

@mmontes11 thoughts?