### PR TITLE
MDBF-568 Fix 11.x missing mysql symlinks

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -108,7 +108,7 @@ RUN set -ex; \
 	} | debconf-set-selections; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
+	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-server-compat="$MARIADB_VERSION" mariadb-client-compat="$MARIADB_VERSION" mariadb-backup socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/11.1/Dockerfile
+++ b/11.1/Dockerfile
@@ -108,7 +108,7 @@ RUN set -ex; \
 	} | debconf-set-selections; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
+	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-server-compat="$MARIADB_VERSION" mariadb-client-compat="$MARIADB_VERSION" mariadb-backup socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/11.2/Dockerfile
+++ b/11.2/Dockerfile
@@ -108,7 +108,7 @@ RUN set -ex; \
 	} | debconf-set-selections; \
 	apt-get update; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
-	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
+	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-server-compat="$MARIADB_VERSION" mariadb-client-compat="$MARIADB_VERSION" mariadb-backup socat \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # purge and re-create /var/lib/mysql with appropriate ownership

--- a/update.sh
+++ b/update.sh
@@ -94,6 +94,10 @@ update_version()
 			fi
 			;&
 		esac
+		if [[ $version =~ 11.[012345] ]]; then
+			# shellcheck disable=SC2016
+			sed -i -e 's/mariadb-server="\$MARIADB_VERSION"/mariadb-server="\$MARIADB_VERSION" mariadb-server-compat="\$MARIADB_VERSION" mariadb-client-compat="\$MARIADB_VERSION"/' "$version/Dockerfile"
+		fi
 }
 
 update_version_array()


### PR DESCRIPTION
During apt `--no-install-recommends` is used which means the `-compat` packages, which contain the symlinks for mysql command line tools, was not installed for 11.x.

This patch explicitly adds them back.