### PR TITLE
MDEV-31529: MariaDB docker pipeline is failing

### DIFF
--- a/.test/run.sh
+++ b/.test/run.sh
@@ -254,7 +254,7 @@ killoff
 		--silent \
 		-e "show create user")
 	# shellcheck disable=SC2016
-	[ "${createuser//\'/\`}" == 'CREATE USER `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "I wasn't created how I was expected"
+	[ "${createuser//\'/\`}" == 'CREATE USER `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "mysql@localhost wasn't created how I was expected"
 
 	grants="$(docker exec --user mysql -i \
 		$cname \
@@ -263,7 +263,7 @@ killoff
 		-e show\ grants)"
 
 	# shellcheck disable=SC2016
-	[ "${grants//\'/\`}" == 'GRANT USAGE ON *.* TO `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "I wasn't granted what I was expected"
+	[ "${grants//\'/\`}" == 'GRANT USAGE ON *.* TO `mysql`@`localhost` IDENTIFIED VIA unix_socket' ] || die "mysql@localhost wasn't granted what I was expected"
 
 	createuser=$(docker exec --user mysql -i \
 		"$cname" \
@@ -271,7 +271,7 @@ killoff
 		--silent \
 		-e "show create user")
 	# shellcheck disable=SC2016
-	[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`localhost` IDENTIFIED' ]] || die "I wasn't created how I was expected"
+	[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`::1` IDENTIFIED' ]] || die "healtheck wasn't created how I was expected"
 
 	grants="$(docker exec --user mysql -i \
 		$cname \
@@ -279,8 +279,7 @@ killoff
 		--silent \
 		-e show\ grants)"
 
-	# shellcheck disable=SC2016
-	[[ "${grants//\'/\`}" =~ 'GRANT USAGE ON *.* TO `healthcheck`@`localhost`' ]] || die "I wasn't granted what I was expected"
+	[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`::1\` ]] || die "healthcheck wasn't granted what I was expected"
 	killoff
 
 	;&

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -270,8 +270,9 @@ killoff
 		$mariadb --defaults-file=/var/lib/mysql/.my-healthcheck.cnf \
 		--silent \
 		-e "show create user")
-	# shellcheck disable=SC2016
-	[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`::1` IDENTIFIED' ]] || die "healtheck wasn't created how I was expected"
+	# shellcheck disable=SC2016,SC2076
+	[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`::1` IDENTIFIED' ]] || \
+		[[ "${createuser//\'/\`}" =~ 'CREATE USER `healthcheck`@`127.0.0.1` IDENTIFIED' ]] || die "healtheck wasn't created how I was expected"
 
 	grants="$(docker exec --user mysql -i \
 		$cname \
@@ -279,7 +280,8 @@ killoff
 		--silent \
 		-e show\ grants)"
 
-	[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`::1\` ]] || die "healthcheck wasn't granted what I was expected"
+	[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`::1\` ]] || \
+		[[ "${grants//\'/\`}" =~ GRANT\ USAGE\ ON\ *.*\ TO\ \`healthcheck\`@\`127.0.0.1\` ]] || die "healthcheck wasn't granted what I was expected"
 	killoff
 
 	;&

--- a/10.10/Dockerfile
+++ b/10.10/Dockerfile
@@ -107,6 +107,8 @@ RUN set -ex; \
 		echo "mariadb-server" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \

--- a/10.11/Dockerfile
+++ b/10.11/Dockerfile
@@ -107,6 +107,8 @@ RUN set -ex; \
 		echo "mariadb-server" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -109,6 +109,8 @@ RUN set -ex; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -109,6 +109,8 @@ RUN set -ex; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -109,6 +109,8 @@ RUN set -ex; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \

--- a/10.9/Dockerfile
+++ b/10.9/Dockerfile
@@ -107,6 +107,8 @@ RUN set -ex; \
 		echo "mariadb-server" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -107,6 +107,8 @@ RUN set -ex; \
 		echo "mariadb-server" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \

--- a/11.1/Dockerfile
+++ b/11.1/Dockerfile
@@ -107,6 +107,8 @@ RUN set -ex; \
 		echo "mariadb-server" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \

--- a/11.2/Dockerfile
+++ b/11.2/Dockerfile
@@ -107,6 +107,8 @@ RUN set -ex; \
 		echo "mariadb-server" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -109,6 +109,8 @@ RUN set -ex; \
 		echo "mariadb-server-$MARIADB_MAJOR" mysql-server/root_password_again password 'unused'; \
 	} | debconf-set-selections; \
 	apt-get update; \
+# postinst script creates a datadir, so avoid creating it by faking its existance.
+	mkdir -p /var/lib/mysql/mysql ; touch /var/lib/mysql/mysql/user.frm ; \
 # mariadb-backup is installed at the same time so that `mysql-common` is only installed once from just mariadb repos
 	apt-get install -y --no-install-recommends mariadb-server="$MARIADB_VERSION" mariadb-backup socat \
 	; \


### PR DESCRIPTION
s390x database initialization was slow (thanks @tianon).

We don't use it, so fake its existance so debian install scripts don't consume the intensive part of the installation.

[1] https://github.com/docker-library/official-images/issues/14923