### PR TITLE
REPOSITORY to include debug section by default

### DIFF
--- a/10.10/Dockerfile
+++ b/10.10/Dockerfile
@@ -86,7 +86,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.10.5/repo/ubuntu/ jammy main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.10.5/repo/ubuntu/ jammy main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/10.11/Dockerfile
+++ b/10.11/Dockerfile
@@ -86,7 +86,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.11.4/repo/ubuntu/ jammy main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.11.4/repo/ubuntu/ jammy main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/10.4/Dockerfile
+++ b/10.4/Dockerfile
@@ -88,7 +88,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.4.30/repo/ubuntu/ focal main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.4.30/repo/ubuntu/ focal main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -88,7 +88,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.5.21/repo/ubuntu/ focal main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.5.21/repo/ubuntu/ focal main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -88,7 +88,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.6.14/repo/ubuntu/ focal main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.6.14/repo/ubuntu/ focal main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/10.9/Dockerfile
+++ b/10.9/Dockerfile
@@ -86,7 +86,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.9.7/repo/ubuntu/ jammy main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-10.9.7/repo/ubuntu/ jammy main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -86,7 +86,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.0.2/repo/ubuntu/ jammy main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.0.2/repo/ubuntu/ jammy main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/11.1/Dockerfile
+++ b/11.1/Dockerfile
@@ -86,7 +86,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.1.1/repo/ubuntu/ jammy main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.1.1/repo/ubuntu/ jammy main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/11.2/Dockerfile
+++ b/11.2/Dockerfile
@@ -86,7 +86,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.2.0/repo/ubuntu/ jammy main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.2.0/repo/ubuntu/ jammy main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -88,7 +88,7 @@ ENV MARIADB_VERSION $MARIADB_VERSION
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-%%MARIADB_VERSION_BASIC%%/repo/ubuntu/ %%SUITE%% main"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-%%MARIADB_VERSION_BASIC%%/repo/ubuntu/ %%SUITE%% main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \


### PR DESCRIPTION
This is so someone that wants debug info packages just needs to apt-get install mariadb-server-core{-10.X}-dbgsym to get the right packages after and apt-get update.