### PR TITLE
ubuntu-24.04 base for 11.4

### DIFF
--- a/11.4/Dockerfile
+++ b/11.4/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql --home-dir /var/lib/mysql
@@ -71,7 +71,7 @@ LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \
       org.opencontainers.image.description="MariaDB Database for relational SQL" \
       org.opencontainers.image.documentation="https://hub.docker.com/_/mariadb/" \
-      org.opencontainers.image.base.name="docker.io/library/ubuntu:jammy" \
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:noble" \
       org.opencontainers.image.licenses="GPL-2.0" \
       org.opencontainers.image.source="https://github.com/MariaDB/mariadb-docker" \
       org.opencontainers.image.vendor="MariaDB Community" \
@@ -79,14 +79,14 @@ LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.url="https://github.com/MariaDB/mariadb-docker"
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le s390x
-ARG MARIADB_VERSION=1:11.4.1+maria~ubu2204
+ARG MARIADB_VERSION=1:11.4.1+maria~ubu2404
 ENV MARIADB_VERSION $MARIADB_VERSION
 # release-status:RC
-# release-support-type:Short Term Support
+# release-support-type:Long Term Support
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.4.1/repo/ubuntu/ jammy main main/debug"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.4.1/repo/ubuntu/ noble main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/11.5/Dockerfile
+++ b/11.5/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql --home-dir /var/lib/mysql
@@ -71,7 +71,7 @@ LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.title="MariaDB Database" \
       org.opencontainers.image.description="MariaDB Database for relational SQL" \
       org.opencontainers.image.documentation="https://hub.docker.com/_/mariadb/" \
-      org.opencontainers.image.base.name="docker.io/library/ubuntu:jammy" \
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:noble" \
       org.opencontainers.image.licenses="GPL-2.0" \
       org.opencontainers.image.source="https://github.com/MariaDB/mariadb-docker" \
       org.opencontainers.image.vendor="MariaDB Community" \
@@ -79,14 +79,14 @@ LABEL org.opencontainers.image.authors="MariaDB Community" \
       org.opencontainers.image.url="https://github.com/MariaDB/mariadb-docker"
 
 # bashbrew-architectures: amd64 arm64v8 ppc64le s390x
-ARG MARIADB_VERSION=1:11.5.0+maria~ubu2204
+ARG MARIADB_VERSION=1:11.5.0+maria~ubu2404
 ENV MARIADB_VERSION $MARIADB_VERSION
 # release-status:Alpha
-# release-support-type:Unknown
+# release-support-type:Short Term Support
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # Allowing overriding of REPOSITORY, a URL that includes suite and component for testing and Enterprise Versions
-ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.5.0/repo/ubuntu/ jammy main main/debug"
+ARG REPOSITORY="http://archive.mariadb.org/mariadb-11.5.0/repo/ubuntu/ noble main main/debug"
 
 RUN set -e;\
 	echo "deb ${REPOSITORY}" > /etc/apt/sources.list.d/mariadb.list; \

--- a/update.sh
+++ b/update.sh
@@ -4,16 +4,22 @@ set -Eeuo pipefail
 # Usage ./update.sh [version(multiple)...]
 #
 
-defaultSuite='jammy'
+defaultSuite='noble'
 declare -A suites=(
 	[10.4]='focal'
 	[10.5]='focal'
 	[10.6]='focal'
+	[10.11]='jammy'
+	[11.0]='jammy'
+	[11.1]='jammy'
+	[11.2]='jammy'
+	[11.3]='jammy'
 )
 
 declare -A suffix=(
 	['focal']='ubu2004'
 	['jammy']='ubu2204'
+	['noble']='ubu2404'
 )
 
 #declare -A dpkgArchToBashbrew=(

--- a/versions.json
+++ b/versions.json
@@ -1,11 +1,25 @@
 {
+  "11.5": {
+    "milestone": "11.5",
+    "version": "11.5.0",
+    "fullVersion": "1:11.5.0+maria~ubu2404",
+    "releaseStatus": "Alpha",
+    "supportType": "Short Term Support",
+    "base": "ubuntu:noble",
+    "arches": [
+      "amd64",
+      "arm64v8",
+      "ppc64le",
+      "s390x"
+    ]
+  },
   "11.4": {
     "milestone": "11.4",
     "version": "11.4.1",
-    "fullVersion": "1:11.4.1+maria~ubu2204",
+    "fullVersion": "1:11.4.1+maria~ubu2404",
     "releaseStatus": "RC",
-    "supportType": "Short Term Support",
-    "base": "ubuntu:jammy",
+    "supportType": "Long Term Support",
+    "base": "ubuntu:noble",
     "arches": [
       "amd64",
       "arm64v8",
@@ -122,20 +136,6 @@
       "amd64",
       "arm64v8",
       "ppc64le"
-    ]
-  },
-  "11.5": {
-    "milestone": "11.5",
-    "version": "11.5.0",
-    "fullVersion": "1:11.5.0+maria~ubu2204",
-    "releaseStatus": "Alpha",
-    "supportType": "Unknown",
-    "base": "ubuntu:jammy",
-    "arches": [
-      "amd64",
-      "arm64v8",
-      "ppc64le",
-      "s390x"
     ]
   }
 }


### PR DESCRIPTION
As its for 24.04 delay merge.

11.4.1 RC should be released before this.

Ensure no [scheduled MariaDB releases](https://jira.mariadb.org/projects/MDEV?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased) before April 2024 before merging.