### PR TITLE
Workaround issue #560 by removing character-set-collations

### DIFF
--- a/10.11/Dockerfile
+++ b/10.11/Dockerfile
@@ -125,6 +125,8 @@ RUN set -ex; \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
 	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
+# Issue #560
+	sed -i -e '/character-set-collations/d' /etc/mysql/mariadb.conf.d/50-server.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -127,6 +127,8 @@ RUN set -ex; \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
 	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
+# Issue #560
+	sed -i -e '/character-set-collations/d' /etc/mysql/mariadb.conf.d/50-server.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/10.6/Dockerfile
+++ b/10.6/Dockerfile
@@ -127,6 +127,8 @@ RUN set -ex; \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
 	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
+# Issue #560
+	sed -i -e '/character-set-collations/d' /etc/mysql/mariadb.conf.d/50-server.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -125,6 +125,8 @@ RUN set -ex; \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
 	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
+# Issue #560
+	sed -i -e '/character-set-collations/d' /etc/mysql/mariadb.conf.d/50-server.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/11.1/Dockerfile
+++ b/11.1/Dockerfile
@@ -125,6 +125,8 @@ RUN set -ex; \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
 	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
+# Issue #560
+	sed -i -e '/character-set-collations/d' /etc/mysql/mariadb.conf.d/50-server.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/11.2/Dockerfile
+++ b/11.2/Dockerfile
@@ -125,6 +125,8 @@ RUN set -ex; \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
 	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
+# Issue #560
+	sed -i -e '/character-set-collations/d' /etc/mysql/mariadb.conf.d/50-server.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/11.3/Dockerfile
+++ b/11.3/Dockerfile
@@ -125,6 +125,8 @@ RUN set -ex; \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
 	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
+# Issue #560
+	sed -i -e '/character-set-collations/d' /etc/mysql/mariadb.conf.d/50-server.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/11.4/Dockerfile
+++ b/11.4/Dockerfile
@@ -125,6 +125,8 @@ RUN set -ex; \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
 	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
+# Issue #560
+	sed -i -e '/character-set-collations/d' /etc/mysql/mariadb.conf.d/50-server.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -127,6 +127,8 @@ RUN set -ex; \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
 	printf "[mariadb]\nhost-cache-size=0\nskip-name-resolve\n" > /etc/mysql/mariadb.conf.d/05-skipcache.cnf; \
+# Issue #560
+	sed -i -e '/character-set-collations/d' /etc/mysql/mariadb.conf.d/50-server.cnf; \
 # Issue #327 Correct order of reading directories /etc/mysql/mariadb.conf.d before /etc/mysql/conf.d (mount-point per documentation)
 	if [ -L /etc/mysql/my.cnf ]; then \
 # 10.5+

--- a/update.sh
+++ b/update.sh
@@ -65,7 +65,10 @@ update_version()
 				-e '/memory\.pressure/,+7d' \
 				"$version/docker-entrypoint.sh"
 			sed -i -e 's/ REPLICA\$/ SLAVE$/' "$version"/healthcheck.sh
-			sed -i -e 's/\/run/\/var\/run\//g' "$version/Dockerfile"
+			sed -i -e 's/\/run/\/var\/run\//g' \
+				-e '/character-set-collations/d' \
+				-e '/^# Issue #560/d' \
+				"$version/Dockerfile"
 			;; # almost nothing to see/do here
 		10.5)
 			sed -i -e '/--old-mode/d' \


### PR DESCRIPTION
This only has an effect on the 11.3 and 11.4 that have the configuration item set in their configuration file.

The 10.4 instance doesn't have this file.