### PR TITLE
 Support for `/etc/mysql/mariadb.conf.d` in ubi

### DIFF
--- a/10.11-ubi/docker.cnf
+++ b/10.11-ubi/docker.cnf
@@ -7,4 +7,5 @@ skip-name-resolve
 [client-server]
 socket=/run/mysqld/mariadb.sock
 
+!includedir /etc/mysql/mariadb.conf.d
 !includedir /etc/mysql/conf.d

--- a/10.6-ubi/docker.cnf
+++ b/10.6-ubi/docker.cnf
@@ -7,4 +7,5 @@ skip-name-resolve
 [client-server]
 socket=/run/mysqld/mariadb.sock
 
+!includedir /etc/mysql/mariadb.conf.d
 !includedir /etc/mysql/conf.d

--- a/docker.cnf
+++ b/docker.cnf
@@ -7,4 +7,5 @@ skip-name-resolve
 [client-server]
 socket=/run/mysqld/mariadb.sock
 
+!includedir /etc/mysql/mariadb.conf.d
 !includedir /etc/mysql/conf.d


### PR DESCRIPTION
 Add `/etc/mysql/mariadb.conf.d` to docker.cnf to be compatible with Ubuntu-based image.