### PR TITLE
Compatibility with UBI 8

### DIFF
--- a/10.11-ubi/Dockerfile
+++ b/10.11-ubi/Dockerfile
@@ -35,9 +35,12 @@ RUN curl https://pagure.io/fedora-web/websites/raw/master/f/sites/getfedora.org/
 	microdnf update -y && \
 	microdnf reinstall -y tzdata && \
 	microdnf install -y procps-ng zstd xz jemalloc pwgen pv && \
-	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb && \
+	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera && \
 	microdnf install -y MariaDB-backup-10.11.8 MariaDB-server-10.11.8 && \
-	ln -s /usr/lib64/galera-4/libgalera_smm.so /usr/lib/libgalera_smm.so && \
+  # compatibility with Ubuntu images
+  ln -s /usr/lib64/galera-4/libgalera_smm.so /usr/lib/libgalera_smm.so && \
+  # compatibility with UBI 8
+  ln -s /usr/lib64/galera-4/libgalera_smm.so /usr/lib64/galera/libgalera_smm.so && \
 	microdnf clean all && \
 	rmdir /var/lib/mysql/mysql && \
 	chown -R mysql:mysql /var/lib/mysql /run/mariadb && \

--- a/10.6-ubi/Dockerfile
+++ b/10.6-ubi/Dockerfile
@@ -35,9 +35,12 @@ RUN curl https://pagure.io/fedora-web/websites/raw/master/f/sites/getfedora.org/
 	microdnf update -y && \
 	microdnf reinstall -y tzdata && \
 	microdnf install -y procps-ng zstd xz jemalloc pwgen pv && \
-	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb && \
+	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera && \
 	microdnf install -y MariaDB-backup-10.6.18 MariaDB-server-10.6.18 && \
-	ln -s /usr/lib64/galera-4/libgalera_smm.so /usr/lib/libgalera_smm.so && \
+  # compatibility with Ubuntu images
+  ln -s /usr/lib64/galera-4/libgalera_smm.so /usr/lib/libgalera_smm.so && \
+  # compatibility with UBI 8
+  ln -s /usr/lib64/galera-4/libgalera_smm.so /usr/lib64/galera/libgalera_smm.so && \
 	microdnf clean all && \
 	rmdir /var/lib/mysql/mysql && \
 	chown -R mysql:mysql /var/lib/mysql /run/mariadb && \

--- a/Dockerfile-ubi.template
+++ b/Dockerfile-ubi.template
@@ -35,9 +35,12 @@ RUN curl https://pagure.io/fedora-web/websites/raw/master/f/sites/getfedora.org/
 	microdnf update -y && \
 	microdnf reinstall -y tzdata && \
 	microdnf install -y procps-ng zstd xz jemalloc pwgen pv && \
-	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb && \
+	mkdir -p /etc/mysql/conf.d /etc/mysql/mariadb.conf.d/ /var/lib/mysql/mysql /run/mariadb /usr/lib64/galera && \
 	microdnf install -y MariaDB-backup-%%MARIADB_VERSION_BASIC%% MariaDB-server-%%MARIADB_VERSION_BASIC%% && \
-	ln -s /usr/lib64/galera-4/libgalera_smm.so /usr/lib/libgalera_smm.so && \
+  # compatibility with Ubuntu images
+  ln -s /usr/lib64/galera-4/libgalera_smm.so /usr/lib/libgalera_smm.so && \
+  # compatibility with UBI 8
+  ln -s /usr/lib64/galera-4/libgalera_smm.so /usr/lib64/galera/libgalera_smm.so && \
 	microdnf clean all && \
 	rmdir /var/lib/mysql/mysql && \
 	chown -R mysql:mysql /var/lib/mysql /run/mariadb && \


### PR DESCRIPTION
In UBI 8 based images, the Galera library is located at `/usr/lib64/galera/libgalera_smm.so`, which is also the default value used by the operator:
https://github.com/mariadb-operator/mariadb-operator/blob/60c16b560be6da72d32cbc1a1b923509a347220e/Makefile#L69

This PR provides compatibility with UBI 8 images by creating a symlink from `/usr/lib64/galera-4/libgalera_smm.so` (UBI 9) to `/usr/lib64/galera/libgalera_smm.so` (UBI 8).