### PR TITLE
ubi: docker.cnf to match Ubuntu versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
       - uses: actions/checkout@v3
-      - uses: docker-library/bashbrew@v0.1.8
+      - uses: docker-library/bashbrew@v0.1.12
       - id: generate-jobs
         name: Generate Jobs
         run: |

--- a/10.11-ubi/Dockerfile
+++ b/10.11-ubi/Dockerfile
@@ -30,6 +30,8 @@ RUN set -eux; \
 
 COPY docker.cnf /etc/my.cnf.d/
 
+RUN chown 0644 /etc/my.cnf.d/docker.cnf
+
 COPY MariaDB.repo /etc/yum.repos.d/
 
 # HasRequiredLabel requirement from Red Hat OpenShift Software Certification

--- a/10.11-ubi/docker.cnf
+++ b/10.11-ubi/docker.cnf
@@ -4,6 +4,11 @@
 host-cache-size=0
 skip-name-resolve
 
+expire_logs_days=10
+character-set-server=utf8mb4
+
+collation-server=utf8mb4_general_ci # 10*
+
 [client-server]
 socket=/run/mariadb/mariadb.sock
 

--- a/10.6-ubi/Dockerfile
+++ b/10.6-ubi/Dockerfile
@@ -30,6 +30,8 @@ RUN set -eux; \
 
 COPY docker.cnf /etc/my.cnf.d/
 
+RUN chown 0644 /etc/my.cnf.d/docker.cnf
+
 COPY MariaDB.repo /etc/yum.repos.d/
 
 # HasRequiredLabel requirement from Red Hat OpenShift Software Certification

--- a/10.6-ubi/docker.cnf
+++ b/10.6-ubi/docker.cnf
@@ -4,6 +4,11 @@
 host-cache-size=0
 skip-name-resolve
 
+expire_logs_days=10
+character-set-server=utf8mb4
+
+collation-server=utf8mb4_general_ci # 10*
+
 [client-server]
 socket=/run/mariadb/mariadb.sock
 

--- a/11.4-ubi/Dockerfile
+++ b/11.4-ubi/Dockerfile
@@ -30,6 +30,8 @@ RUN set -eux; \
 
 COPY docker.cnf /etc/my.cnf.d/
 
+RUN chown 0644 /etc/my.cnf.d/docker.cnf
+
 COPY MariaDB.repo /etc/yum.repos.d/
 
 # HasRequiredLabel requirement from Red Hat OpenShift Software Certification

--- a/11.4-ubi/docker.cnf
+++ b/11.4-ubi/docker.cnf
@@ -4,6 +4,11 @@
 host-cache-size=0
 skip-name-resolve
 
+expire_logs_days=10
+character-set-server=utf8mb4
+
+character-set-collations=utf8mb4=uca1400_ai_ci # 11.3+
+
 [client-server]
 socket=/run/mariadb/mariadb.sock
 

--- a/11.5-ubi/Dockerfile
+++ b/11.5-ubi/Dockerfile
@@ -30,6 +30,8 @@ RUN set -eux; \
 
 COPY docker.cnf /etc/my.cnf.d/
 
+RUN chown 0644 /etc/my.cnf.d/docker.cnf
+
 COPY MariaDB.repo /etc/yum.repos.d/
 
 # HasRequiredLabel requirement from Red Hat OpenShift Software Certification
@@ -56,7 +58,7 @@ LABEL org.opencontainers.image.authors="MariaDB Community" \
 # bashbrew-architectures: amd64 arm64v8 ppc64le s390x
 ARG MARIADB_VERSION=11.5.1
 # release-status:RC
-# release-support-type:Short Term Support
+# release-support-type:Rolling
 # (https://downloads.mariadb.org/rest-api/mariadb/)
 
 # missing pwgen(epel), jemalloc(epel) (as entrypoint/user extensions)

--- a/11.5-ubi/docker.cnf
+++ b/11.5-ubi/docker.cnf
@@ -4,6 +4,11 @@
 host-cache-size=0
 skip-name-resolve
 
+expire_logs_days=10
+character-set-server=utf8mb4
+
+character-set-collations=utf8mb4=uca1400_ai_ci # 11.3+
+
 [client-server]
 socket=/run/mariadb/mariadb.sock
 

--- a/Dockerfile-ubi.template
+++ b/Dockerfile-ubi.template
@@ -28,7 +28,7 @@ RUN set -eux; \
 	gosu --version; \
 	gosu nobody true
 
-COPY docker.cnf /etc/my.cnf.d/
+COPY --chmod=0644 docker.cnf /etc/my.cnf.d/
 
 COPY MariaDB.repo /etc/yum.repos.d/
 

--- a/docker.cnf
+++ b/docker.cnf
@@ -4,6 +4,12 @@
 host-cache-size=0
 skip-name-resolve
 
+expire_logs_days=10
+character-set-server=utf8mb4
+
+character-set-collations=utf8mb4=uca1400_ai_ci # 11.3+
+collation-server=utf8mb4_general_ci # 10*
+
 [client-server]
 socket=/run/mariadb/mariadb.sock
 

--- a/update.sh
+++ b/update.sh
@@ -49,7 +49,11 @@ update_version()
 	else
 		suite=
 		fullVersion=$mariaVersion
-		cp docker.cnf "$dir"
+		if [[ $version = 10.* ]]; then
+			sed -e '/character-set-collations/d' docker.cnf > "$dir/docker.cnf"
+		else
+			sed -e '/collation-server/d' docker.cnf > "$dir/docker.cnf"
+		fi
 		sed -e "s!%%MARIADB_VERSION%%!${version%-*}!" MariaDB-ubi.repo > "$dir"/MariaDB.repo
 	fi
 

--- a/versions.json
+++ b/versions.json
@@ -171,7 +171,7 @@
     "version": "11.5.1",
     "fullVersion": "11.5.1",
     "releaseStatus": "RC",
-    "supportType": "Short Term Support",
+    "supportType": "Rolling",
     "base": "ubi9",
     "arches": [
       "amd64",


### PR DESCRIPTION
Also when building, ensure that the docker.cnf
is readonly otherwise it won't be read by the server.

Seems 11.5 has been declared rolling.