### PR TITLE
chowns are non-fatal

### DIFF
--- a/10.11-ubi/docker-entrypoint.sh
+++ b/10.11-ubi/docker-entrypoint.sh
@@ -204,9 +204,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -526,7 +526,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/10.11-ubi/docker-entrypoint.sh
+++ b/10.11-ubi/docker-entrypoint.sh
@@ -206,7 +206,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/10.11/docker-entrypoint.sh
+++ b/10.11/docker-entrypoint.sh
@@ -204,9 +204,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -526,7 +526,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/10.11/docker-entrypoint.sh
+++ b/10.11/docker-entrypoint.sh
@@ -206,7 +206,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -206,7 +206,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 	fi
 }

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -204,9 +204,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 	fi
 }
@@ -517,7 +517,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/10.6-ubi/docker-entrypoint.sh
+++ b/10.6-ubi/docker-entrypoint.sh
@@ -206,7 +206,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 	fi
 }

--- a/10.6-ubi/docker-entrypoint.sh
+++ b/10.6-ubi/docker-entrypoint.sh
@@ -204,9 +204,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 	fi
 }
@@ -518,7 +518,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -206,7 +206,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 	fi
 }

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -204,9 +204,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 	fi
 }
@@ -518,7 +518,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/11.1/docker-entrypoint.sh
+++ b/11.1/docker-entrypoint.sh
@@ -204,9 +204,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -526,7 +526,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/11.1/docker-entrypoint.sh
+++ b/11.1/docker-entrypoint.sh
@@ -206,7 +206,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/11.2/docker-entrypoint.sh
+++ b/11.2/docker-entrypoint.sh
@@ -204,9 +204,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -526,7 +526,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/11.2/docker-entrypoint.sh
+++ b/11.2/docker-entrypoint.sh
@@ -206,7 +206,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/11.4-ubi/docker-entrypoint.sh
+++ b/11.4-ubi/docker-entrypoint.sh
@@ -206,9 +206,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -528,7 +528,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/11.4-ubi/docker-entrypoint.sh
+++ b/11.4-ubi/docker-entrypoint.sh
@@ -208,7 +208,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/11.4/docker-entrypoint.sh
+++ b/11.4/docker-entrypoint.sh
@@ -206,9 +206,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -528,7 +528,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/11.4/docker-entrypoint.sh
+++ b/11.4/docker-entrypoint.sh
@@ -208,7 +208,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/11.5-ubi/docker-entrypoint.sh
+++ b/11.5-ubi/docker-entrypoint.sh
@@ -206,9 +206,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -528,7 +528,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/11.5-ubi/docker-entrypoint.sh
+++ b/11.5-ubi/docker-entrypoint.sh
@@ -208,7 +208,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/11.5/docker-entrypoint.sh
+++ b/11.5/docker-entrypoint.sh
@@ -206,9 +206,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -528,7 +528,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/11.5/docker-entrypoint.sh
+++ b/11.5/docker-entrypoint.sh
@@ -208,7 +208,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/11.6-ubi/docker-entrypoint.sh
+++ b/11.6-ubi/docker-entrypoint.sh
@@ -206,9 +206,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -528,7 +528,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/11.6-ubi/docker-entrypoint.sh
+++ b/11.6-ubi/docker-entrypoint.sh
@@ -208,7 +208,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/11.6/docker-entrypoint.sh
+++ b/11.6/docker-entrypoint.sh
@@ -206,9 +206,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -528,7 +528,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/11.6/docker-entrypoint.sh
+++ b/11.6/docker-entrypoint.sh
@@ -208,7 +208,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -206,9 +206,9 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -528,7 +528,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -208,7 +208,9 @@ docker_create_db_directories() {
 		# this will cause less disk access than `chown -R`
 		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)


### PR DESCRIPTION
There may be cases where specific files are readonly, like .my-healthcheck.cnf due to filesystem mounts.

So lets make the ownership/permission changes optional.

Closes: #573