### PR TITLE
correct healthcheck.sh under --require-secure-transport

### DIFF
--- a/.test/run.sh
+++ b/.test/run.sh
@@ -765,7 +765,7 @@ fi
 		--network=container:"$master_host" \
 		--health-cmd='healthcheck.sh --replication_io --replication_sql --replication_seconds_behind_master=0 --replication' \
 		--health-interval=3s \
-		"$image" --server-id=2 --port 3307)
+		"$image" --server-id=2 --port 3307 --require-secure-transport=1)
 
 	c="${DOCKER_LIBRARY_START_TIMEOUT:-10}"
 	until docker exec "$cid" healthcheck.sh --connect --replication_io --replication_sql --replication_seconds_behind_master=0 --replication || [ "$c" -eq 0 ]

--- a/10.11-ubi/docker-entrypoint.sh
+++ b/10.11-ubi/docker-entrypoint.sh
@@ -353,7 +353,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/10.11-ubi/healthcheck.sh
+++ b/10.11-ubi/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -42,6 +42,7 @@ _process_sql()
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -55,6 +56,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -68,9 +79,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -225,6 +238,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -351,3 +365,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/10.11/docker-entrypoint.sh
+++ b/10.11/docker-entrypoint.sh
@@ -353,7 +353,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/10.11/healthcheck.sh
+++ b/10.11/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -42,6 +42,7 @@ _process_sql()
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -55,6 +56,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -68,9 +79,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -225,6 +238,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -351,3 +365,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -344,7 +344,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/10.5/healthcheck.sh
+++ b/10.5/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -42,6 +42,7 @@ _process_sql()
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -55,6 +56,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -68,9 +79,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -225,6 +238,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -351,3 +365,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/10.6-ubi/docker-entrypoint.sh
+++ b/10.6-ubi/docker-entrypoint.sh
@@ -345,7 +345,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/10.6-ubi/healthcheck.sh
+++ b/10.6-ubi/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -42,6 +42,7 @@ _process_sql()
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -55,6 +56,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -68,9 +79,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -225,6 +238,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -351,3 +365,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -345,7 +345,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/10.6/healthcheck.sh
+++ b/10.6/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -42,6 +42,7 @@ _process_sql()
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -55,6 +56,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -68,9 +79,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -225,6 +238,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -351,3 +365,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/11.1/docker-entrypoint.sh
+++ b/11.1/docker-entrypoint.sh
@@ -353,7 +353,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/11.1/healthcheck.sh
+++ b/11.1/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -42,6 +42,7 @@ _process_sql()
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -55,6 +56,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -68,9 +79,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -225,6 +238,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -351,3 +365,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/11.2/docker-entrypoint.sh
+++ b/11.2/docker-entrypoint.sh
@@ -353,7 +353,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/11.2/healthcheck.sh
+++ b/11.2/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -42,6 +42,7 @@ _process_sql()
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -55,6 +56,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -68,9 +79,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -225,6 +238,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -351,3 +365,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/11.4-ubi/docker-entrypoint.sh
+++ b/11.4-ubi/docker-entrypoint.sh
@@ -355,7 +355,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/11.4-ubi/healthcheck.sh
+++ b/11.4-ubi/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -43,6 +43,7 @@ _process_sql()
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
 		--skip-ssl --skip-ssl-verify-server-cert \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -56,6 +57,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -70,9 +81,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -227,6 +240,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -353,3 +367,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/11.4/docker-entrypoint.sh
+++ b/11.4/docker-entrypoint.sh
@@ -355,7 +355,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/11.4/healthcheck.sh
+++ b/11.4/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -43,6 +43,7 @@ _process_sql()
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
 		--skip-ssl --skip-ssl-verify-server-cert \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -56,6 +57,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -70,9 +81,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -227,6 +240,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -353,3 +367,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/11.5-ubi/docker-entrypoint.sh
+++ b/11.5-ubi/docker-entrypoint.sh
@@ -355,7 +355,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/11.5-ubi/healthcheck.sh
+++ b/11.5-ubi/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -43,6 +43,7 @@ _process_sql()
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
 		--skip-ssl --skip-ssl-verify-server-cert \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -56,6 +57,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -70,9 +81,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -227,6 +240,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -353,3 +367,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/11.5/docker-entrypoint.sh
+++ b/11.5/docker-entrypoint.sh
@@ -355,7 +355,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/11.5/healthcheck.sh
+++ b/11.5/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -43,6 +43,7 @@ _process_sql()
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
 		--skip-ssl --skip-ssl-verify-server-cert \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -56,6 +57,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -70,9 +81,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -227,6 +240,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -353,3 +367,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/11.6-ubi/docker-entrypoint.sh
+++ b/11.6-ubi/docker-entrypoint.sh
@@ -355,7 +355,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/11.6-ubi/healthcheck.sh
+++ b/11.6-ubi/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -43,6 +43,7 @@ _process_sql()
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
 		--skip-ssl --skip-ssl-verify-server-cert \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -56,6 +57,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -70,9 +81,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -227,6 +240,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -353,3 +367,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/11.6/docker-entrypoint.sh
+++ b/11.6/docker-entrypoint.sh
@@ -355,7 +355,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/11.6/healthcheck.sh
+++ b/11.6/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -43,6 +43,7 @@ _process_sql()
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
 		--skip-ssl --skip-ssl-verify-server-cert \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -56,6 +57,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -70,9 +81,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -227,6 +240,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -353,3 +367,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -355,7 +355,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -43,6 +43,7 @@ _process_sql()
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
 		--skip-ssl --skip-ssl-verify-server-cert \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -56,6 +57,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -70,9 +81,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -227,6 +240,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -353,3 +367,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi


### PR DESCRIPTION
require-secure-transport on the server mandates that tls or unix socket be used. The healthcheck user doesn't have explict tls credentials, so would have failed. 11.4+ would have tls negiotated, except in #594 it was disabled for people that didn't configure ssl-ca correctly.

To resolve this _process_sql adds an explict --protocol socket to get around the default configuration of 'protocol=tcp' in .my-healthcheck.sh. The protocol=tcp was there to catch people who put `healthcheck.sh --innodb_initialized` to discover it checked that in the starting phase of the container, without a tcp connection being available, it still returned true.

We work around this my making a connection test always occur in the healthcheck.

Remove the protocol=tcp from the generation of .my-healthcheck.cnf files.

--connect, as a method that requires to test the connection, we add a mechanims that examines @@skip_networking and considers that if false, the connection is viable. We made a unix socket connection to do the test, which is active the same time as tcp sockets are.

This alternate --connect method would have only worked the credentials of the healthcheck user where valid. If it isn't fall back to looking for "Can't connect".

Closes: #596