### PR TITLE
Specify `mysql` as container user

### DIFF
--- a/10.11-ubi/Dockerfile
+++ b/10.11-ubi/Dockerfile
@@ -107,5 +107,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/10.6-ubi/Dockerfile
+++ b/10.6-ubi/Dockerfile
@@ -108,5 +108,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/11.4-ubi/Dockerfile
+++ b/11.4-ubi/Dockerfile
@@ -107,5 +107,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/11.5-ubi/Dockerfile
+++ b/11.5-ubi/Dockerfile
@@ -107,5 +107,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]

--- a/Dockerfile-ubi.template
+++ b/Dockerfile-ubi.template
@@ -108,5 +108,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER mysql
 EXPOSE 3306
 CMD ["mariadbd"]


### PR DESCRIPTION
Explicitly declare `mysql` as the container user to be compliant with RedHat container certification :
- https://docs.redhat.com/en/documentation/red_hat_software_certification/2024/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction#con-image-content-requirements_openshift-sw-cert-policy-container-images (See the `RunAsNonRoot` requirement)



Without this, the certifications tests fail:

```bash
Run make preflight-image-submit
/home/runner/work/mariadb-enterprise-server-docker/mariadb-enterprise-server-docker/bin/preflight check container mariadb:11.4.2-ubi\
	--submit \
	--pyxis-api-token=*** \
	--certification-project-id=***\
	--docker-config /home/runner/.docker/config.json  
time="2024-07-03T13:06:2[8](https://github.com/mariadb-corporation/mariadb-enterprise-server-docker/actions/runs/9778444292/job/26995266059#step:3:9)Z" level=info msg="certification library version" version="1.9.4 <commit: 7abf1ac0cc2c9156a16557d532da5d365b662423>"
time="2024-07-03T13:06:2[9](https://github.com/mariadb-corporation/mariadb-enterprise-server-docker/actions/runs/9778444292/job/26995266059#step:3:10)Z" level=info msg="running checks for mariadb:11.4.2-ubi for platform amd64"
time="2024-07-03T13:06:30Z" level=info msg="target image" image="mariadb:11.4.2-ubi"
time="2024-07-03T13:06:42Z" level=info msg="check completed" check=HasLicense result=PASSED
time="2024-07-03T13:06:42Z" level=info msg="check completed" check=HasUniqueTag result=PASSED
time="2024-07-03T13:06:42Z" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
time="2024-07-03T13:06:42Z" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
time="2024-07-03T13:06:42Z" level=info msg="check completed" check=HasRequiredLabel result=PASSED
time="2024-07-03T13:06:42Z" level=info msg="detected empty USER. Presumed to be running as root"
time="2024-07-03T13:06:42Z" level=info msg="USER value must be provided and be a non-root value for this check to pass"
time="2024-07-03T13:06:42Z" level=info msg="check completed" check=RunAsNonRoot result=FAILED
time="2024-07-03T13:06:51Z" level=info msg="check completed" check=HasModifiedFiles result=PASSED
time="2024-07-03T13:06:52Z" level=info msg="check completed" check=BasedOnUbi result=PASSED
time="2024-07-03T13:06:52Z" level=info msg="This image's tag 11.4.2-ubi will be paired with digest sha256:39d890585ce0b56da608121b8cb3c429cc40ed37a9478fb60f1b19001f4db57a once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
time="2024-07-03T13:06:52Z" level=info msg="preparing results that will be submitted to Red Hat"
{
    "image": "mariadb:11.4.2-ubi",
    "passed": false,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "1.9.4",
        "commit": "7abf1ac0cc2c9156a16557d532da5d365b662423"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 78,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata."
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 86[10](https://github.com/mariadb-corporation/mariadb-enterprise-server-docker/actions/runs/9778444292/job/26995266059#step:3:11),
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 14[13](https://github.com/mariadb-corporation/mariadb-enterprise-server-docker/actions/runs/9778444292/job/26995266059#step:3:14),
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            }
        ],
        "failed": [
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 2,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
                "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/[20](https://github.com/mariadb-corporation/mariadb-enterprise-server-docker/actions/runs/9778444292/job/26995266059#step:3:21)24/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ],
        "errors": []
    }
}
``` 

But it can easily fixed by adding `USER mysql`: 

```bash
Run make preflight-image-submit
/home/runner/work/mariadb-enterprise-server-docker/mariadb-enterprise-server-docker/bin/preflight check container mariadbmmontes/mariadb:11.4-ubi\
	--submit \
	--pyxis-api-token=*** \
	--certification-project-id=***\
	--docker-config /home/runner/.docker/config.json  
time="2024-07-03T13:32:02Z" level=info msg="certification library version" version="1.9.4 <commit: 7abf1ac0cc2c9156a16557d532da5d365b662423>"
time="2024-07-03T13:32:03Z" level=info msg="running checks for mariadbmmontes/mariadb:11.4-ubi for platform amd64"
time="2024-07-03T13:32:04Z" level=info msg="target image" image="mariadbmmontes/mariadb:11.4-ubi"
time="2024-07-03T13:32:17Z" level=info msg="check completed" check=HasLicense result=PASSED
time="2024-07-03T13:32:17Z" level=info msg="check completed" check=HasUniqueTag result=PASSED
time="2024-07-03T13:32:17Z" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
time="2024-07-03T13:32:17Z" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
time="2024-07-03T13:32:17Z" level=info msg="check completed" check=HasRequiredLabel result=PASSED
time="2024-07-03T13:32:17Z" level=info msg="USER mysql specified that is non-root"
time="2024-07-03T13:32:17Z" level=info msg="check completed" check=RunAsNonRoot result=PASSED
time="2024-07-03T13:32:26Z" level=info msg="check completed" check=HasModifiedFiles result=PASSED
time="2024-07-03T13:32:27Z" level=info msg="check completed" check=BasedOnUbi result=PASSED
time="2024-07-03T13:32:27Z" level=info msg="This image's tag 11.4-ubi will be paired with digest sha256:929c790b1f2fe6b33[8](https://github.com/mariadb-corporation/mariadb-enterprise-server-docker/actions/runs/9778853851/job/26996634761#step:3:9)dbf47a1ee6548f206809402de02e25c20aaeed287d94b3 once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
{
    "image": "mariadbmmontes/mariadb:11.4-ubi",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "1.[9](https://github.com/mariadb-corporation/mariadb-enterprise-server-docker/actions/runs/9778853851/job/26996634761#step:3:10).4",
        "commit": "7abf1ac0cc2c9156a16557d532da5d365b662423"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 68,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
time="2024-07-03T13:32:27Z" level=info msg="preparing results that will be submitted to Red Hat"
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata."
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 8648,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 1322,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            }
        ],
        "failed": [],
        "errors": []
    }
}
time="2024-07-03T13:32:35Z" level=info msg="Test results have been submitted to Red Hat."
time="2024-07-03T13:32:35Z" level=info msg="These results will be reviewed by Red Hat for final certification."
time="2024-07-03T13:32:35Z" level=info msg="The container's image id is: 668552eee45daa25e3771a3d."
time="2024-07-03T13:32:35Z" level=info msg="Please check https://connect.redhat.com/projects/6663409ad61a[11](https://github.com/mariadb-corporation/mariadb-enterprise-server-docker/actions/runs/9778853851/job/26996634761#step:3:12)fcb8a08e8c/images/668552eee45daa25e3771a3d/scan-results to view scan results."
time="2024-07-03T[13](https://github.com/mariadb-corporation/mariadb-enterprise-server-docker/actions/runs/9778853851/job/26996634761#step:3:14):32:35Z" level=info msg="Please check https://connect.redhat.com/projects/6663409ad61a11fcb8a08e8c/overview to monitor the progress."
time="2024-07-03T13:32:35Z" level=info msg="Preflight result: PASSED"
``` 