### PR TITLE
healthcheck correct connect result

### DIFF
--- a/.test/run.sh
+++ b/.test/run.sh
@@ -72,7 +72,7 @@ runandwait()
 		)"
 		port_int=$port
 	fi
-	waiting=${DOCKER_LIBRARY_START_TIMEOUT:-10}
+	waiting=${DOCKER_LIBRARY_START_TIMEOUT:-15}
 	echo "waiting to start..."
 	set +e +o pipefail +x
 	while [ "$waiting" -gt 0 ]

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -929,25 +929,33 @@ zstd "${initdb}"/*zst*
 	# select @@skip-networking via tcp successful
 	docker exec "$cname" healthcheck.sh --connect
 
+	# shellcheck disable=SC2016
 	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`127.0.0.1` ACCOUNT LOCK'
+	# shellcheck disable=SC2016
 	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`::1` ACCOUNT LOCK'
 
 	# ERROR 4151 (HY000): Access denied, this account is locked
 	docker exec "$cname" healthcheck.sh --connect
 
+	# shellcheck disable=SC2016
 	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`127.0.0.1` WITH MAX_QUERIES_PER_HOUR 1 ACCOUNT UNLOCK'
+	# shellcheck disable=SC2016
 	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`::1` WITH MAX_QUERIES_PER_HOUR 1 ACCOUNT UNLOCK'
 
 	# ERROR 1226 (42000) at line 1: User '\''healthcheck'\'' has exceeded the '\''max_queries_per_hour'\'' resource (current value: 1)'
 	docker exec "$cname" healthcheck.sh --connect
 	docker exec "$cname" healthcheck.sh --connect
 
+	# shellcheck disable=SC2016
 	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`127.0.0.1` WITH MAX_QUERIES_PER_HOUR 2000 PASSWORD EXPIRE'
+	# shellcheck disable=SC2016
 	mariadbclient -u root -psoverysecret -e 'alter user healthcheck@`::1` WITH MAX_QUERIES_PER_HOUR 2000 PASSWORD EXPIRE'
 	# ERROR 1820 (HY000) at line 1: You must SET PASSWORD before executing this statement
 	docker exec "$cname" healthcheck.sh --connect
 
+	# shellcheck disable=SC2016
 	mariadbclient -u root -psoverysecret -e 'set password for healthcheck@`127.0.0.1` = PASSWORD("mismatch")'
+	# shellcheck disable=SC2016
 	mariadbclient -u root -psoverysecret -e 'set password for healthcheck@`::1` = PASSWORD("mismatch")'
 
 	# ERROR 1045 (28000): Access denied

--- a/10.5/healthcheck.sh
+++ b/10.5/healthcheck.sh
@@ -65,24 +65,39 @@ connect()
 			return "$s";
 			;;
 	esac
-	# falling back to this if there wasn't a connection answer.
-	set +e +o pipefail
-	# (on second extra_file)
-	# shellcheck disable=SC2086
-	mysql ${nodefaults:+--no-defaults} \
+	# falling back to tcp if there wasn't a connection answer.
+	s=$(mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}}  \
-		-h localhost --protocol tcp -e 'select 1' 2>&1 \
-		| grep -qF "Can't connect"
-	local ret=${PIPESTATUS[1]}
-	set -eo pipefail
-	if (( "$ret" == 0 )); then
-		# grep Matched "Can't connect" so we fail
-		connect_s=1
-	else
-		connect_s=0
-	fi
+		-h localhost --protocol tcp \
+		--skip-column-names --batch --skip-print-query-on-error \
+		-e 'select @@skip_networking' 2>&1)
+
+	case "$s" in
+		1)      # skip-networking=1 (no network)
+			;&
+		ERROR\ 2002\ \(HY000\):*)
+			# cannot connect
+			connect_s=1
+			;;
+		0)      # skip-networking=0
+			;&
+		ERROR\ 1820\ \(HY000\)*) # password expire
+			;&
+		ERROR\ 4151\ \(HY000\):*) # account locked
+			;&
+		ERROR\ 1226\ \(42000\)*) # resource limit exceeded
+			;&
+		ERROR\ 1[0-9][0-9][0-9]\ \(28000\):*)
+			# grep access denied and other 28000 client errors - we did connect
+			connect_s=0
+			;;
+		*)
+			>&2 echo "Unknown error $s"
+			connect_s=1
+			;;
+	esac
 	return $connect_s
 }
 
@@ -365,8 +380,8 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
-if [ -z "$connect_s" ]; then
-	# we didn't do a connnect test, so the current success status is suspicious
+if [ "$connect_s" != "0" ]; then
+	# we didn't pass a connnect test, so the current success status is suspicious
 	# return what connect thinks.
 	connect
 	exit $?

--- a/11.4-ubi/healthcheck.sh
+++ b/11.4-ubi/healthcheck.sh
@@ -66,25 +66,40 @@ connect()
 			return "$s";
 			;;
 	esac
-	# falling back to this if there wasn't a connection answer.
-	set +e +o pipefail
-	# (on second extra_file)
-	# shellcheck disable=SC2086
-	mariadb ${nodefaults:+--no-defaults} \
+	# falling back to tcp if there wasn't a connection answer.
+	s=$(mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}}  \
 		--skip-ssl --skip-ssl-verify-server-cert \
-		-h localhost --protocol tcp -e 'select 1' 2>&1 \
-		| grep -qF "Can't connect"
-	local ret=${PIPESTATUS[1]}
-	set -eo pipefail
-	if (( "$ret" == 0 )); then
-		# grep Matched "Can't connect" so we fail
-		connect_s=1
-	else
-		connect_s=0
-	fi
+		-h localhost --protocol tcp \
+		--skip-column-names --batch --skip-print-query-on-error \
+		-e 'select @@skip_networking' 2>&1)
+
+	case "$s" in
+		1)      # skip-networking=1 (no network)
+			;&
+		ERROR\ 2002\ \(HY000\):*)
+			# cannot connect
+			connect_s=1
+			;;
+		0)      # skip-networking=0
+			;&
+		ERROR\ 1820\ \(HY000\)*) # password expire
+			;&
+		ERROR\ 4151\ \(HY000\):*) # account locked
+			;&
+		ERROR\ 1226\ \(42000\)*) # resource limit exceeded
+			;&
+		ERROR\ 1[0-9][0-9][0-9]\ \(28000\):*)
+			# grep access denied and other 28000 client errors - we did connect
+			connect_s=0
+			;;
+		*)
+			>&2 echo "Unknown error $s"
+			connect_s=1
+			;;
+	esac
 	return $connect_s
 }
 
@@ -367,8 +382,8 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
-if [ -z "$connect_s" ]; then
-	# we didn't do a connnect test, so the current success status is suspicious
+if [ "$connect_s" != "0" ]; then
+	# we didn't pass a connnect test, so the current success status is suspicious
 	# return what connect thinks.
 	connect
 	exit $?

--- a/11.4/healthcheck.sh
+++ b/11.4/healthcheck.sh
@@ -66,25 +66,40 @@ connect()
 			return "$s";
 			;;
 	esac
-	# falling back to this if there wasn't a connection answer.
-	set +e +o pipefail
-	# (on second extra_file)
-	# shellcheck disable=SC2086
-	mariadb ${nodefaults:+--no-defaults} \
+	# falling back to tcp if there wasn't a connection answer.
+	s=$(mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}}  \
 		--skip-ssl --skip-ssl-verify-server-cert \
-		-h localhost --protocol tcp -e 'select 1' 2>&1 \
-		| grep -qF "Can't connect"
-	local ret=${PIPESTATUS[1]}
-	set -eo pipefail
-	if (( "$ret" == 0 )); then
-		# grep Matched "Can't connect" so we fail
-		connect_s=1
-	else
-		connect_s=0
-	fi
+		-h localhost --protocol tcp \
+		--skip-column-names --batch --skip-print-query-on-error \
+		-e 'select @@skip_networking' 2>&1)
+
+	case "$s" in
+		1)      # skip-networking=1 (no network)
+			;&
+		ERROR\ 2002\ \(HY000\):*)
+			# cannot connect
+			connect_s=1
+			;;
+		0)      # skip-networking=0
+			;&
+		ERROR\ 1820\ \(HY000\)*) # password expire
+			;&
+		ERROR\ 4151\ \(HY000\):*) # account locked
+			;&
+		ERROR\ 1226\ \(42000\)*) # resource limit exceeded
+			;&
+		ERROR\ 1[0-9][0-9][0-9]\ \(28000\):*)
+			# grep access denied and other 28000 client errors - we did connect
+			connect_s=0
+			;;
+		*)
+			>&2 echo "Unknown error $s"
+			connect_s=1
+			;;
+	esac
 	return $connect_s
 }
 
@@ -367,8 +382,8 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
-if [ -z "$connect_s" ]; then
-	# we didn't do a connnect test, so the current success status is suspicious
+if [ "$connect_s" != "0" ]; then
+	# we didn't pass a connnect test, so the current success status is suspicious
 	# return what connect thinks.
 	connect
 	exit $?

--- a/11.5/healthcheck.sh
+++ b/11.5/healthcheck.sh
@@ -66,25 +66,40 @@ connect()
 			return "$s";
 			;;
 	esac
-	# falling back to this if there wasn't a connection answer.
-	set +e +o pipefail
-	# (on second extra_file)
-	# shellcheck disable=SC2086
-	mariadb ${nodefaults:+--no-defaults} \
+	# falling back to tcp if there wasn't a connection answer.
+	s=$(mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}}  \
 		--skip-ssl --skip-ssl-verify-server-cert \
-		-h localhost --protocol tcp -e 'select 1' 2>&1 \
-		| grep -qF "Can't connect"
-	local ret=${PIPESTATUS[1]}
-	set -eo pipefail
-	if (( "$ret" == 0 )); then
-		# grep Matched "Can't connect" so we fail
-		connect_s=1
-	else
-		connect_s=0
-	fi
+		-h localhost --protocol tcp \
+		--skip-column-names --batch --skip-print-query-on-error \
+		-e 'select @@skip_networking' 2>&1)
+
+	case "$s" in
+		1)      # skip-networking=1 (no network)
+			;&
+		ERROR\ 2002\ \(HY000\):*)
+			# cannot connect
+			connect_s=1
+			;;
+		0)      # skip-networking=0
+			;&
+		ERROR\ 1820\ \(HY000\)*) # password expire
+			;&
+		ERROR\ 4151\ \(HY000\):*) # account locked
+			;&
+		ERROR\ 1226\ \(42000\)*) # resource limit exceeded
+			;&
+		ERROR\ 1[0-9][0-9][0-9]\ \(28000\):*)
+			# grep access denied and other 28000 client errors - we did connect
+			connect_s=0
+			;;
+		*)
+			>&2 echo "Unknown error $s"
+			connect_s=1
+			;;
+	esac
 	return $connect_s
 }
 
@@ -367,8 +382,8 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
-if [ -z "$connect_s" ]; then
-	# we didn't do a connnect test, so the current success status is suspicious
+if [ "$connect_s" != "0" ]; then
+	# we didn't pass a connnect test, so the current success status is suspicious
 	# return what connect thinks.
 	connect
 	exit $?

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -66,25 +66,40 @@ connect()
 			return "$s";
 			;;
 	esac
-	# falling back to this if there wasn't a connection answer.
-	set +e +o pipefail
-	# (on second extra_file)
-	# shellcheck disable=SC2086
-	mariadb ${nodefaults:+--no-defaults} \
+	# falling back to tcp if there wasn't a connection answer.
+	s=$(mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}}  \
 		--skip-ssl --skip-ssl-verify-server-cert \
-		-h localhost --protocol tcp -e 'select 1' 2>&1 \
-		| grep -qF "Can't connect"
-	local ret=${PIPESTATUS[1]}
-	set -eo pipefail
-	if (( "$ret" == 0 )); then
-		# grep Matched "Can't connect" so we fail
-		connect_s=1
-	else
-		connect_s=0
-	fi
+		-h localhost --protocol tcp \
+		--skip-column-names --batch --skip-print-query-on-error \
+		-e 'select @@skip_networking' 2>&1)
+
+	case "$s" in
+		1)      # skip-networking=1 (no network)
+			;&
+		ERROR\ 2002\ \(HY000\):*)
+			# cannot connect
+			connect_s=1
+			;;
+		0)      # skip-networking=0
+			;&
+		ERROR\ 1820\ \(HY000\)*) # password expire
+			;&
+		ERROR\ 4151\ \(HY000\):*) # account locked
+			;&
+		ERROR\ 1226\ \(42000\)*) # resource limit exceeded
+			;&
+		ERROR\ 1[0-9][0-9][0-9]\ \(28000\):*)
+			# grep access denied and other 28000 client errors - we did connect
+			connect_s=0
+			;;
+		*)
+			>&2 echo "Unknown error $s"
+			connect_s=1
+			;;
+	esac
 	return $connect_s
 }
 
@@ -367,8 +382,8 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
-if [ -z "$connect_s" ]; then
-	# we didn't do a connnect test, so the current success status is suspicious
+if [ "$connect_s" != "0" ]; then
+	# we didn't pass a connnect test, so the current success status is suspicious
 	# return what connect thinks.
 	connect
 	exit $?

--- a/main-ubi/healthcheck.sh
+++ b/main-ubi/healthcheck.sh
@@ -66,25 +66,40 @@ connect()
 			return "$s";
 			;;
 	esac
-	# falling back to this if there wasn't a connection answer.
-	set +e +o pipefail
-	# (on second extra_file)
-	# shellcheck disable=SC2086
-	mariadb ${nodefaults:+--no-defaults} \
+	# falling back to tcp if there wasn't a connection answer.
+	s=$(mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}}  \
 		--skip-ssl --skip-ssl-verify-server-cert \
-		-h localhost --protocol tcp -e 'select 1' 2>&1 \
-		| grep -qF "Can't connect"
-	local ret=${PIPESTATUS[1]}
-	set -eo pipefail
-	if (( "$ret" == 0 )); then
-		# grep Matched "Can't connect" so we fail
-		connect_s=1
-	else
-		connect_s=0
-	fi
+		-h localhost --protocol tcp \
+		--skip-column-names --batch --skip-print-query-on-error \
+		-e 'select @@skip_networking' 2>&1)
+
+	case "$s" in
+		1)      # skip-networking=1 (no network)
+			;&
+		ERROR\ 2002\ \(HY000\):*)
+			# cannot connect
+			connect_s=1
+			;;
+		0)      # skip-networking=0
+			;&
+		ERROR\ 1820\ \(HY000\)*) # password expire
+			;&
+		ERROR\ 4151\ \(HY000\):*) # account locked
+			;&
+		ERROR\ 1226\ \(42000\)*) # resource limit exceeded
+			;&
+		ERROR\ 1[0-9][0-9][0-9]\ \(28000\):*)
+			# grep access denied and other 28000 client errors - we did connect
+			connect_s=0
+			;;
+		*)
+			>&2 echo "Unknown error $s"
+			connect_s=1
+			;;
+	esac
 	return $connect_s
 }
 
@@ -367,8 +382,8 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
-if [ -z "$connect_s" ]; then
-	# we didn't do a connnect test, so the current success status is suspicious
+if [ "$connect_s" != "0" ]; then
+	# we didn't pass a connnect test, so the current success status is suspicious
 	# return what connect thinks.
 	connect
 	exit $?

--- a/main/healthcheck.sh
+++ b/main/healthcheck.sh
@@ -66,25 +66,40 @@ connect()
 			return "$s";
 			;;
 	esac
-	# falling back to this if there wasn't a connection answer.
-	set +e +o pipefail
-	# (on second extra_file)
-	# shellcheck disable=SC2086
-	mariadb ${nodefaults:+--no-defaults} \
+	# falling back to tcp if there wasn't a connection answer.
+	s=$(mariadb ${nodefaults:+--no-defaults} \
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}}  \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}}  \
 		--skip-ssl --skip-ssl-verify-server-cert \
-		-h localhost --protocol tcp -e 'select 1' 2>&1 \
-		| grep -qF "Can't connect"
-	local ret=${PIPESTATUS[1]}
-	set -eo pipefail
-	if (( "$ret" == 0 )); then
-		# grep Matched "Can't connect" so we fail
-		connect_s=1
-	else
-		connect_s=0
-	fi
+		-h localhost --protocol tcp \
+		--skip-column-names --batch --skip-print-query-on-error \
+		-e 'select @@skip_networking' 2>&1)
+
+	case "$s" in
+		1)      # skip-networking=1 (no network)
+			;&
+		ERROR\ 2002\ \(HY000\):*)
+			# cannot connect
+			connect_s=1
+			;;
+		0)      # skip-networking=0
+			;&
+		ERROR\ 1820\ \(HY000\)*) # password expire
+			;&
+		ERROR\ 4151\ \(HY000\):*) # account locked
+			;&
+		ERROR\ 1226\ \(42000\)*) # resource limit exceeded
+			;&
+		ERROR\ 1[0-9][0-9][0-9]\ \(28000\):*)
+			# grep access denied and other 28000 client errors - we did connect
+			connect_s=0
+			;;
+		*)
+			>&2 echo "Unknown error $s"
+			connect_s=1
+			;;
+	esac
 	return $connect_s
 }
 
@@ -367,8 +382,8 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
-if [ -z "$connect_s" ]; then
-	# we didn't do a connnect test, so the current success status is suspicious
+if [ "$connect_s" != "0" ]; then
+	# we didn't pass a connnect test, so the current success status is suspicious
 	# return what connect thinks.
 	connect
 	exit $?


### PR DESCRIPTION
Based on user reports, a `connect` test can observer a non-"Can't connect" error message.

Because this passes other tests, like innodb_initialized might succeeded.

The final test -z "$connect_s" is also true, leaving the user with an incorrect test result.

Maybe the .my-healthcheck cnf isn't fully written yet?
```
+ mariadb --defaults-extra-file=/var/lib/mysql/.my-healthcheck.cnf --skip-ssl --skip-ssl-verify-server-cert -h localhost --protocol tcp -e 'select 1'
+ grep -qF 'Can'\''t connect'
+ local ret=1
+ set -eo pipefail
+ ((  1 == 0  ))
+ connect_s=0
+ return 0
+ test=
+ shift
+ '[' 1 -gt 0 ']'
+ case "$1" in
+ test=innodb_initialized
+ '[' -n innodb_initialized ']'
```
Either way, ruggardize the final test to ensure a healthy connect test occurred.

Closes #610