### PR TITLE
Disable replication start on initialization

### DIFF
--- a/10.11-ubi/docker-entrypoint.sh
+++ b/10.11-ubi/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		&
 	declare -g MARIADB_PID
@@ -458,7 +459,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -471,7 +471,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -502,7 +501,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -598,8 +596,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -624,8 +621,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/10.11-ubi/healthcheck.sh
+++ b/10.11-ubi/healthcheck.sh
@@ -361,6 +361,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/10.11/docker-entrypoint.sh
+++ b/10.11/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		&
 	declare -g MARIADB_PID
@@ -458,7 +459,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -471,7 +471,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -502,7 +501,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -598,8 +596,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -624,8 +621,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/10.11/healthcheck.sh
+++ b/10.11/healthcheck.sh
@@ -361,6 +361,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/10.5/docker-entrypoint.sh
+++ b/10.5/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		&
 	declare -g MARIADB_PID
@@ -449,7 +450,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -462,7 +462,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -493,7 +492,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -589,8 +587,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -615,8 +612,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/10.5/healthcheck.sh
+++ b/10.5/healthcheck.sh
@@ -361,6 +361,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/10.6-ubi/docker-entrypoint.sh
+++ b/10.6-ubi/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		&
 	declare -g MARIADB_PID
@@ -450,7 +451,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -463,7 +463,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -494,7 +493,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -590,8 +588,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -616,8 +613,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/10.6-ubi/healthcheck.sh
+++ b/10.6-ubi/healthcheck.sh
@@ -361,6 +361,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/10.6/docker-entrypoint.sh
+++ b/10.6/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		&
 	declare -g MARIADB_PID
@@ -450,7 +451,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -463,7 +463,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -494,7 +493,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -590,8 +588,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -616,8 +613,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/10.6/healthcheck.sh
+++ b/10.6/healthcheck.sh
@@ -361,6 +361,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/11.2/docker-entrypoint.sh
+++ b/11.2/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		&
 	declare -g MARIADB_PID
@@ -458,7 +459,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -471,7 +471,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -502,7 +501,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -598,8 +596,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -624,8 +621,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/11.2/healthcheck.sh
+++ b/11.2/healthcheck.sh
@@ -361,6 +361,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/11.4-ubi/docker-entrypoint.sh
+++ b/11.4-ubi/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--skip-ssl --ssl-cert='' --ssl-key='' --ssl-ca='' \
 		&
@@ -460,7 +461,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -473,7 +473,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -504,7 +503,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -600,8 +598,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -626,8 +623,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/11.4-ubi/healthcheck.sh
+++ b/11.4-ubi/healthcheck.sh
@@ -363,6 +363,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/11.4/docker-entrypoint.sh
+++ b/11.4/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--skip-ssl --ssl-cert='' --ssl-key='' --ssl-ca='' \
 		&
@@ -460,7 +461,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -473,7 +473,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -504,7 +503,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -600,8 +598,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -626,8 +623,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/11.4/healthcheck.sh
+++ b/11.4/healthcheck.sh
@@ -363,6 +363,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--skip-ssl --ssl-cert='' --ssl-key='' --ssl-ca='' \
 		&
@@ -460,7 +461,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -473,7 +473,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -504,7 +503,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -600,8 +598,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -626,8 +623,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -363,6 +363,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/main-ubi/docker-entrypoint.sh
+++ b/main-ubi/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--skip-ssl --ssl-cert='' --ssl-key='' --ssl-ca='' \
 		&
@@ -460,7 +461,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -473,7 +473,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -504,7 +503,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -600,8 +598,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -626,8 +623,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/main-ubi/healthcheck.sh
+++ b/main-ubi/healthcheck.sh
@@ -363,6 +363,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/main/docker-entrypoint.sh
+++ b/main/docker-entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--skip-ssl --ssl-cert='' --ssl-key='' --ssl-ca='' \
 		&
@@ -460,7 +461,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -473,7 +473,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -504,7 +503,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -600,8 +598,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -626,8 +623,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/main/healthcheck.sh
+++ b/main/healthcheck.sh
@@ -363,6 +363,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;


### PR DESCRIPTION
START REPLIA was inssued during initializing which mean that even before /docker-entrypoint/initdb.d there was initializtion going on.

Entrypoints that needed data initialzation didn't complete with this nicely. Also if there wasn't any initialization there would be little time for the replication to acheive anything before being shutdown ready for the final start.

Moved --skip-slave-start to the default docker_temp_server_start implementation.

Closes #614